### PR TITLE
DEL-1249 added security-checks,image parameters and test cases for security checks,custom image scan test.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,3 +25,10 @@ jobs:
       - uses: actions/checkout@v3
       - name: lint
         run: lint --id trivy
+  shellcheck:
+    name: Shellcheck
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Run ShellCheck
+      uses: ludeeus/action-shellcheck@master

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Add the following to your `pipeline.yml`:
 steps:
   - command: ls
     plugins:
-      - trivy#v1.8.0: ~
+      - trivy#v1.13.0: ~
 ```
 Define `--exit-code` option as a plugin parameter in  `pipeline.yml` to fail the pipeline when there are vulnerabilities:
 
@@ -27,8 +27,8 @@ Define `--exit-code` option as a plugin parameter in  `pipeline.yml` to fail the
 steps:
   - command: ls
     plugins:
-      - trivy#v1.8.0:
-	exit-code: 1
+      - trivy#v1.13.0:
+        exit-code: 1
 ```
 
 Define `--severity` option as a plugin parameter in  `pipeline.yml` to scan specific type of vulnerabilities:	
@@ -38,8 +38,8 @@ Below is an example for scanning `CRITICAL` vulnerabilities.
 steps:
   - command: ls
     plugins:
-      - trivy#v1.8.0:
-	severity: "CRITICAL"
+      - trivy#v1.13.0:
+        severity: "CRITICAL"
 ```
 ## Developing
 

--- a/hooks/post-checkout
+++ b/hooks/post-checkout
@@ -1,15 +1,17 @@
 #!/bin/bash
 
-default_image="aquasec/trivy:0.29.2"
-image="${BUILDKITE_PLUGIN_TRIVY_IMAGE:-$default_image}"
+default_version="0.29.2"
+version="${BUILDKITE_PLUGIN_TRIVY_VERSION:-$default_version}"
+image="aquasec/trivy:${version}"
 
 args=()
+fsargs=()
 
 if [[ "${BUILDKITE_PLUGIN_TRIVY_EXIT_CODE:-0}" -eq 1 ]] ; then
-  export args+=("--exit-code 1")
+  args+=("--exit-code 1")
   echo "using exit-code=1 option while scanning"
 else
-  export args+=("--exit-code 0")
+  args+=("--exit-code 0")
   echo "using exit-code=0 option while scanning"
 fi
 
@@ -20,19 +22,36 @@ fi
 # fi
 
 if [[ -n "${BUILDKITE_PLUGIN_TRIVY_SEVERITY:-}" ]] ; then
-  export args+=("--severity ${BUILDKITE_PLUGIN_TRIVY_SEVERITY}")
+  args+=("--severity ${BUILDKITE_PLUGIN_TRIVY_SEVERITY}")
   echo "using non-default severity types"
 fi
-echo "scanning filesystem"
-docker run -v $PWD:/workdir --rm $image fs ${args[@]} --security-checks vuln,config /workdir
 
-if [[ -f $PWD/Dockerfile ]]; then
-  docker build -t local/${BUILDKITE_PIPELINE_ID}:${BUILDKITE_COMMIT} .
-  echo "scanning container image"
-  docker run -v /var/run/docker.sock:/var/run/docker.sock --rm $image image ${args[@]} local/${BUILDKITE_PIPELINE_ID}:${BUILDKITE_COMMIT}
-elif [[ ${BUILDKITE_TESTING} ]]; then
-    cd $PWD/tests/testapp
-    docker build -t local/${BUILDKITE_PIPELINE_ID}:${BUILDKITE_COMMIT} .
-  echo "scanning container image"
-  docker run -v /var/run/docker.sock:/var/run/docker.sock --rm $image image ${args[@]} local/${BUILDKITE_PIPELINE_ID}:${BUILDKITE_COMMIT} 
-fi  
+if [[ -n "${BUILDKITE_PLUGIN_TRIVY_SECURITY_CHECKS:-}" ]] ; then
+  fsargs+=("--security-checks ${BUILDKITE_PLUGIN_TRIVY_SECURITY_CHECKS}")
+  echo "using $BUILDKITE_PLUGIN_TRIVY_SECURITY_CHECKS security checks"
+else
+  echo "using default security checks"
+  fsargs+=("--security-checks vuln,config")
+fi
+
+echo "scanning filesystem"
+docker run -v "${PWD}":/workdir --rm "$image" fs "${args[@]}" "${fsargs[@]}" /workdir
+
+
+if [[ -n "${BUILDKITE_PLUGIN_TRIVY_IMAGE_REF:-}" ]] ; then
+  echo "using image from parameters"
+  if [[ "${BUILDKITE_TESTING}" ]]; then
+  	docker pull "${BUILDKITE_PLUGIN_TRIVY_IMAGE_REF}"
+  fi
+else
+export BUILDKITE_PLUGIN_TRIVY_IMAGE_REF=local/"${BUILDKITE_PIPELINE_ID}":"${BUILDKITE_COMMIT}"
+  if [[ -f $PWD/Dockerfile ]]; then
+    docker build -t "${BUILDKITE_PLUGIN_TRIVY_IMAGE_REF}" .
+  elif [[ ${BUILDKITE_TESTING} ]]; then
+    cd "${PWD}"/tests/testapp || exit
+    docker build -t "${BUILDKITE_PLUGIN_TRIVY_IMAGE_REF}" . 
+  fi
+fi
+
+echo "scanning container image"
+docker run -v /var/run/docker.sock:/var/run/docker.sock --rm "${image}" image "${args[@]}" "${BUILDKITE_PLUGIN_TRIVY_IMAGE_REF}"

--- a/plugin.yml
+++ b/plugin.yml
@@ -12,6 +12,10 @@ configuration:
       type: string
     ignore-unfixed:
       type: boolean
-    image:      
+    trivy-version:      
+      type: string
+    security-checks:
+      type: string
+    image-ref:
       type: string
   additionalProperties: false

--- a/tests/post-checkout.bats
+++ b/tests/post-checkout.bats
@@ -91,6 +91,38 @@ setup() {
   assert_output --partial "using exit-code=1 option while scanning"
 }
 
+@test "fs scan of a test app with only vulnerbility security check" {
+  export BUILDKITE_PLUGIN_TRIVY_SECURITY_CHECKS="vuln"
+  stub docker "run --rm -v $PWD/tests/testapp:/workdir  --rm aquasec/trivy:0.29.2 fs --severity $BUILDKITE_PLUGIN_TRIVY_SECURITY_CHECKS /workdir"
+
+  run "$PWD/hooks/post-checkout"
+
+  assert_success
+  assert_output --partial "scanning filesystem"
+  assert_output --partial "using vuln security checks"
+}
+
+@test "fs scan of a test app with vulnerbility and configuration security check" {
+  stub docker "run --rm -v $PWD/tests/testapp:/workdir  --rm aquasec/trivy:0.29.2 fs --severity $BUILDKITE_PLUGIN_TRIVY_SECURITY_CHECKS /workdir"
+
+  run "$PWD/hooks/post-checkout"
+
+  assert_success
+  assert_output --partial "scanning filesystem"
+  assert_output --partial "using default security checks"
+}
+
+@test "fs scan of a test app with vulnerbility,secret and configuration security check" {
+  export BUILDKITE_PLUGIN_TRIVY_SECURITY_CHECKS="vuln,secret,config"
+  stub docker "run --rm -v $PWD/tests/testapp:/workdir  --rm aquasec/trivy:0.29.2 fs --severity $BUILDKITE_PLUGIN_TRIVY_SECURITY_CHECKS /workdir"
+
+  run "$PWD/hooks/post-checkout"
+
+  assert_success
+  assert_output --partial "scanning filesystem"
+  assert_output --partial "using vuln,secret,config security checks"
+}
+
 @test "scan of a test application image" {
   export BUILDKITE_PIPELINE_ID=12345
   export BUILDKITE_COMMIT=67890
@@ -102,4 +134,15 @@ setup() {
 
   assert_success
   assert_output --partial "scanning container image"
+}
+
+@test "scan of a custom image" {
+  export BUILDKITE_PLUGIN_TRIVY_IMAGE_REF="nginx"
+  export BUILDKITE_TESTING=true
+  stub docker "run --rm -v $PWD/tests/testapp:/workdir  --rm aquasec/trivy:0.29.2 image ${BUILDKITE_PLUGIN_TRIVY_IMAGE_SCAN}"
+
+  run "$PWD/hooks/post-checkout"
+
+  assert_success
+  assert_output --partial "using image from parameters"
 }


### PR DESCRIPTION
By default, Trivy scans for vulnerabilities only. 

In this plugin, we have configured to scan vulnerabilities and config by default.

Users can change this behaviour by passing security check type as parameter with "security-checks:vuln" or "security-checks:vuln,secret,config" for this behaviour we have added following test cases.

- fs scan of a test app with only vulnerability security check
- fs scan of a test app with vulnerability and configuration security check
- fs scan of a test app with vulnerability,secret and configuration security check

Added code to scan container images. Users can pass image as a parameter. If no parameter is passed and if code finds a dockerfile in repo root folder., It will build a docker image and scan it. 
Added test case to scan a test app image and a nginx image pulled from docker hub.

