### PR TITLE
Automatically create GH release if a tag is pushed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,23 @@
+---
+name: Release
+
+on:
+  push:
+    tags:
+      - v**
+
+jobs:
+  auto-release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          generate_release_notes: true
+


### PR DESCRIPTION
This automatically creates a GitHub release with appropropriate release
notes once a tag is pushed. This reduces the amount of manual work
needed.

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
