### PR TITLE
Fix tests and stop building container images

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,10 @@
 name: tests
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
 jobs:
   plugin-tests:
     name: Tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,3 +32,5 @@ jobs:
     - uses: actions/checkout@v2
     - name: Run ShellCheck
       uses: ludeeus/action-shellcheck@master
+      env:
+        SHELLCHECK_OPTS: -x

--- a/hooks/post-checkout
+++ b/hooks/post-checkout
@@ -1,17 +1,69 @@
 #!/bin/bash
 
-default_version="0.29.2"
-version="${BUILDKITE_PLUGIN_TRIVY_VERSION:-$default_version}"
-image="aquasec/trivy:${version}"
+DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
+
+# shellcheck source=lib/trivy-env.sh
+. "$DIR/../lib/trivy-env.sh"
 
 args=()
 fsargs=()
 
+# Helper functions
+##################
+
+fail_with_message() {
+  display_error "$1"
+  exit 1
+}
+
+display_error() {
+  message="$1"
+  echo "🚨 $message" >&2
+  buildkite-agent annotate --style error "$message<br />" --context publish --append
+}
+
+display_success() {
+  message="$1"
+  echo "$message"
+  buildkite-agent annotate --style success "$message<br />" --context publish --append
+}
+
+docker_metadata_list_into_result() {
+    # Can be tags or labels
+    field="$1"
+    filepath="$DOCKER_METADATA_DIR/$field"
+
+    if [[ ! -f "$filepath" ]] ; then
+      fail_with_message "No '$field' directory found in $DOCKER_METADATA_DIR"
+    fi
+
+    result=()
+
+    for line in $(cat "$filepath") ; do
+      result+=("$line")
+    done
+}
+
+docker_metadata_file_exists() {
+  file=$1
+  if [[ ! -d "${DOCKER_METADATA_DIR:-}" ]] ; then
+    return 1
+  fi
+  if [[ ! -f "$DOCKER_METADATA_DIR/$file" ]] ; then
+    return 1
+  fi
+  return 0
+}
+
+
+# Hook
+######
+
 if [[ "${BUILDKITE_PLUGIN_TRIVY_EXIT_CODE:-0}" -eq 1 ]] ; then
-  args+=("--exit-code 1")
+  args+=("--exit-code" "1")
   echo "using exit-code=1 option while scanning"
 else
-  args+=("--exit-code 0")
+  args+=("--exit-code" "0")
   echo "using exit-code=0 option while scanning"
 fi
 
@@ -22,36 +74,68 @@ fi
 # fi
 
 if [[ -n "${BUILDKITE_PLUGIN_TRIVY_SEVERITY:-}" ]] ; then
-  args+=("--severity ${BUILDKITE_PLUGIN_TRIVY_SEVERITY}")
+  args+=("--severity" "${BUILDKITE_PLUGIN_TRIVY_SEVERITY}")
   echo "using non-default severity types"
 fi
 
 if [[ -n "${BUILDKITE_PLUGIN_TRIVY_SECURITY_CHECKS:-}" ]] ; then
-  fsargs+=("--security-checks ${BUILDKITE_PLUGIN_TRIVY_SECURITY_CHECKS}")
+  fsargs+=("--security-checks" "${BUILDKITE_PLUGIN_TRIVY_SECURITY_CHECKS}")
   echo "using $BUILDKITE_PLUGIN_TRIVY_SECURITY_CHECKS security checks"
 else
   echo "using default security checks"
-  fsargs+=("--security-checks vuln,config")
+  fsargs+=("--security-checks" "vuln,config")
 fi
 
 echo "scanning filesystem"
 docker run -v "${PWD}":/workdir --rm "$image" fs "${args[@]}" "${fsargs[@]}" /workdir
+status=$?
+
+if [[ $status -ne 0 ]]; then
+  display_error "trivy found vulnerabilities in repository. See the job output for details."
+else
+  display_success "trivy didn't find any relevant vulnerabilities in the repository"
+fi
 
 
-if [[ -n "${BUILDKITE_PLUGIN_TRIVY_IMAGE_REF:-}" ]] ; then
-  echo "using image from parameters"
-  if [[ "${BUILDKITE_TESTING}" ]]; then
-  	docker pull "${BUILDKITE_PLUGIN_TRIVY_IMAGE_REF}"
+# Verify container image (if any)
+targetimageref="${BUILDKITE_PLUGIN_TRIVY_IMAGE_REF:-}"
+if [[ -z "$targetimageref" ]] ; then
+
+  # Parse docker-metadata references
+  if docker_metadata_file_exists tags ; then
+    if docker_metadata_list_into_result tags ; then
+      # We only use the first tag that we got from docker-metadata.
+      # In theory, all the tags coming from here point to the same
+      # image.
+      targetimageref="${result[0]}"
+      unset result
+    fi
   fi
 else
-export BUILDKITE_PLUGIN_TRIVY_IMAGE_REF=local/"${BUILDKITE_PIPELINE_ID}":"${BUILDKITE_COMMIT}"
-  if [[ -f $PWD/Dockerfile ]]; then
-    docker build -t "${BUILDKITE_PLUGIN_TRIVY_IMAGE_REF}" .
-  elif [[ ${BUILDKITE_TESTING} ]]; then
-    cd "${PWD}"/tests/testapp || exit
-    docker build -t "${BUILDKITE_PLUGIN_TRIVY_IMAGE_REF}" . 
-  fi
+  echo "using image '$targetimageref' from parameters"
+fi
+
+# We can't parse an image if we have no references to parse.
+# This might be intended, so let's just pass.
+if [[ -z "$targetimageref" ]]; then
+  echo "no image to scan"
+  display_success "No container image was scanned due to a lack of an image reference. This is fine."
+  exit 0
+fi
+
+# If the image is not present locally, pull it
+if [[ -z "$(docker images -q $targetimageref 2> /dev/null)" ]]; then
+  docker pull $targetimageref
+else
+  echo "image '$targetimageref' already present locally"
 fi
 
 echo "scanning container image"
-docker run -v /var/run/docker.sock:/var/run/docker.sock --rm "${image}" image "${args[@]}" "${BUILDKITE_PLUGIN_TRIVY_IMAGE_REF}"
+docker run -v /var/run/docker.sock:/var/run/docker.sock --rm "${image}" image "${args[@]}" "$targetimageref"
+status=$?
+
+if [[ $status -ne 0 ]]; then
+  fail_with_message "trivy found vulnerabilities in the container image. See the job output for details."
+else
+  display_success "trivy didn't find any relevant vulnerabilities in the container image"
+fi

--- a/hooks/post-checkout
+++ b/hooks/post-checkout
@@ -39,9 +39,9 @@ docker_metadata_list_into_result() {
 
     result=()
 
-    for line in $(cat "$filepath") ; do
+    while read -r line; do
       result+=("$line")
-    done
+    done < "$filepath"
 }
 
 docker_metadata_file_exists() {
@@ -124,8 +124,8 @@ if [[ -z "$targetimageref" ]]; then
 fi
 
 # If the image is not present locally, pull it
-if [[ -z "$(docker images -q $targetimageref 2> /dev/null)" ]]; then
-  docker pull $targetimageref
+if [[ -z $(docker images -q "$targetimageref" 2> /dev/null) ]]; then
+  docker pull "$targetimageref"
 else
   echo "image '$targetimageref' already present locally"
 fi

--- a/hooks/post-checkout
+++ b/hooks/post-checkout
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
-
-# shellcheck source=lib/trivy-env.sh
-. "$DIR/../lib/trivy-env.sh"
+# NOTE(jaosorior): This is duplicated in the tests.
+export default_version="0.29.2"
+export version="${BUILDKITE_PLUGIN_TRIVY_VERSION:-$default_version}"
+export image="aquasec/trivy:${version}"
 
 args=()
 fsargs=()

--- a/lib/trivy-env.sh
+++ b/lib/trivy-env.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+export default_version="0.29.2"
+export version="${BUILDKITE_PLUGIN_TRIVY_VERSION:-$default_version}"
+export image="aquasec/trivy:${version}"

--- a/lib/trivy-env.sh
+++ b/lib/trivy-env.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-export default_version="0.29.2"
-export version="${BUILDKITE_PLUGIN_TRIVY_VERSION:-$default_version}"
-export image="aquasec/trivy:${version}"

--- a/tests/post-checkout.bats
+++ b/tests/post-checkout.bats
@@ -2,7 +2,10 @@
 
 load '/usr/local/lib/bats/load.bash'
 
-source "$PWD/lib/trivy-env.sh"
+# NOTE(jaosorior): This is duplicated in the hook.
+export default_version="0.29.2"
+export version="${BUILDKITE_PLUGIN_TRIVY_VERSION:-$default_version}"
+export image="aquasec/trivy:${version}"
 
 # Uncomment the following line to debug stub failures
 # export BUILDKITE_AGENT_STUB_DEBUG=/dev/tty

--- a/tests/post-checkout.bats
+++ b/tests/post-checkout.bats
@@ -1,148 +1,291 @@
 #!/usr/bin/env bats
 
-setup() {
-  load "$BATS_PLUGIN_PATH/load.bash"
-}
+load '/usr/local/lib/bats/load.bash'
+
+source "$PWD/lib/trivy-env.sh"
+
+# Uncomment the following line to debug stub failures
+# export BUILDKITE_AGENT_STUB_DEBUG=/dev/tty
 
 @test "fs scan of a test app" {
-
-  stub docker "run --rm -v $PWD/tests/testapp:/workdir  --rm aquasec/trivy:0.29.2 fs /workdir"
+  # TODO(jaosorior): Change the exit code if we change the default
+  stub docker "run -v \"$PWD\":/workdir --rm $image fs --exit-code 0 --security-checks vuln,config /workdir : echo fs scan success"
+  stub buildkite-agent "annotate --style success \"trivy didn't find any relevant vulnerabilities in the repository<br />\" --context publish --append : echo fs scan success" \
+    "annotate --style success \"No container image was scanned due to a lack of an image reference. This is fine.<br />\" --context publish --append : echo no image scan happened" \
 
   run "$PWD/hooks/post-checkout"
 
   assert_success
   assert_output --partial "scanning filesystem"
+  assert_output --partial "fs scan success"
+  assert_output --partial "no image scan happened"
+
+  unstub docker
+  unstub buildkite-agent
 }
 
 @test "fs scan of a test app with exit-code=1" {
   export BUILDKITE_PLUGIN_TRIVY_EXIT_CODE=1
 
-  stub docker "run --rm -v $PWD/tests/testapp:/workdir  --rm aquasec/trivy:0.29.2 fs --exit-code $BUILDKITE_PLUGIN_TRIVY_EXIT_CODE /workdir"
+  stub docker "run -v \"$PWD\":/workdir --rm $image fs --exit-code 1 --security-checks vuln,config /workdir : echo fs scan success"
+  stub buildkite-agent "annotate --style success \"trivy didn't find any relevant vulnerabilities in the repository<br />\" --context publish --append : echo fs scan success" \
+    "annotate --style success \"No container image was scanned due to a lack of an image reference. This is fine.<br />\" --context publish --append : echo no image scan happened" \
 
   run "$PWD/hooks/post-checkout"
 
   assert_success
   assert_output --partial "scanning filesystem"
+  assert_output --partial "fs scan success"
   assert_output --partial "using exit-code=1 option while scanning"
+
+  unstub docker
+  unstub buildkite-agent
 }
 
 @test "fs scan of a test app with exit-code=0" {
   export BUILDKITE_PLUGIN_TRIVY_EXIT_CODE=0
 
-  stub docker "run --rm -v $PWD/tests/testapp:/workdir  --rm aquasec/trivy:0.29.2 fs --exit-code $BUILDKITE_PLUGIN_TRIVY_EXIT_CODE /workdir"
+  stub docker "run -v \"$PWD\":/workdir --rm $image fs --exit-code 0 --security-checks vuln,config /workdir : echo fs scan success"
+  stub buildkite-agent "annotate --style success \"trivy didn't find any relevant vulnerabilities in the repository<br />\" --context publish --append : echo fs scan success" \
+    "annotate --style success \"No container image was scanned due to a lack of an image reference. This is fine.<br />\" --context publish --append : echo no image scan happened" \
 
   run "$PWD/hooks/post-checkout"
 
   assert_success
   assert_output --partial "scanning filesystem"
+  assert_output --partial "fs scan success"
   assert_output --partial "using exit-code=0 option while scanning"
+
+  unstub docker
+  unstub buildkite-agent
+}
+
+@test "fs scan of a test app with exit-code=1 with actual failure" {
+  export BUILDKITE_PLUGIN_TRIVY_EXIT_CODE=1
+
+  stub docker "run -v \"$PWD\":/workdir --rm $image fs --exit-code 1 --security-checks vuln,config /workdir : exit 1"
+  stub buildkite-agent "annotate --style error \"trivy found vulnerabilities in repository. See the job output for details.<br />\" --context publish --append : echo fs scan failure" \
+    "annotate --style success \"No container image was scanned due to a lack of an image reference. This is fine.<br />\" --context publish --append : echo no image scan happened" \
+
+  run "$PWD/hooks/post-checkout"
+
+  assert_success
+  assert_output --partial "scanning filesystem"
+  assert_output --partial "fs scan failure"
+  assert_output --partial "using exit-code=1 option while scanning"
+
+  unstub docker
+  unstub buildkite-agent
 }
 
 @test "fs scan of a test app with non-default severity type CRITICAL" {
   export BUILDKITE_PLUGIN_TRIVY_SEVERITY="CRITICAL"
   export BUILDKITE_PLUGIN_TRIVY_EXIT_CODE=1
 
-  stub docker "run --rm -v $PWD/tests/testapp:/workdir  --rm aquasec/trivy:0.29.2 fs --severity $BUILDKITE_PLUGIN_TRIVY_SEVERITY /workdir"
+  stub docker "run -v \"$PWD\":/workdir --rm $image fs --exit-code 1 --severity $BUILDKITE_PLUGIN_TRIVY_SEVERITY --security-checks vuln,config /workdir : echo fs scan success"
+  stub buildkite-agent "annotate --style success \"trivy didn't find any relevant vulnerabilities in the repository<br />\" --context publish --append : echo fs scan success" \
+    "annotate --style success \"No container image was scanned due to a lack of an image reference. This is fine.<br />\" --context publish --append : echo no image scan happened" \
 
   run "$PWD/hooks/post-checkout"
 
   assert_success
   assert_output --partial "scanning filesystem"
   assert_output --partial "using non-default severity types"
+
+  unstub docker
+  unstub buildkite-agent
 }
 
 @test "fs scan of a test app with non-default severity type CRITICAL and HIGH" {
   export BUILDKITE_PLUGIN_TRIVY_SEVERITY="CRITICAL,HIGH"
   export BUILDKITE_PLUGIN_TRIVY_EXIT_CODE=1
 
-  stub docker "run --rm -v $PWD/tests/testapp:/workdir  --rm aquasec/trivy:0.29.2 fs --severity $BUILDKITE_PLUGIN_TRIVY_SEVERITY /workdir"
+  stub docker "run -v \"$PWD\":/workdir --rm $image fs --exit-code 1 --severity $BUILDKITE_PLUGIN_TRIVY_SEVERITY --security-checks vuln,config /workdir : echo fs scan success"
+  stub buildkite-agent "annotate --style success \"trivy didn't find any relevant vulnerabilities in the repository<br />\" --context publish --append : echo fs scan success" \
+    "annotate --style success \"No container image was scanned due to a lack of an image reference. This is fine.<br />\" --context publish --append : echo no image scan happened" \
 
   run "$PWD/hooks/post-checkout"
 
   assert_success
   assert_output --partial "scanning filesystem"
   assert_output --partial "using non-default severity types"
+
+  unstub docker
+  unstub buildkite-agent
 }
 
 @test "fs scan of a test app with non-default severity type CRITICAL,HIGH and MEDIUM" {
   export BUILDKITE_PLUGIN_TRIVY_SEVERITY="CRITICAL,HIGH,MEDIUM"
   export BUILDKITE_PLUGIN_TRIVY_EXIT_CODE=1
 
-  stub docker "run --rm -v $PWD/tests/testapp:/workdir  --rm aquasec/trivy:0.29.2 fs --severity $BUILDKITE_PLUGIN_TRIVY_SEVERITY /workdir"
+  stub docker "run -v \"$PWD\":/workdir --rm $image fs --exit-code 1 --severity $BUILDKITE_PLUGIN_TRIVY_SEVERITY --security-checks vuln,config /workdir : echo fs scan success"
+  stub buildkite-agent "annotate --style success \"trivy didn't find any relevant vulnerabilities in the repository<br />\" --context publish --append : echo fs scan success" \
+    "annotate --style success \"No container image was scanned due to a lack of an image reference. This is fine.<br />\" --context publish --append : echo no image scan happened" \
 
   run "$PWD/hooks/post-checkout"
 
   assert_success
   assert_output --partial "scanning filesystem"
   assert_output --partial "using non-default severity types"
-}
 
-@test "fs scan of a test app with non-default severity type and non-default exit-code options" {
-  export BUILDKITE_PLUGIN_TRIVY_SEVERITY="CRITICAL"
-  export BUILDKITE_PLUGIN_TRIVY_EXIT_CODE=1
-
-  stub docker "run --rm -v $PWD/tests/testapp:/workdir  --rm aquasec/trivy:0.29.2 fs --severity $BUILDKITE_PLUGIN_TRIVY_SEVERITY --exit-code $BUILDKITE_PLUGIN_TRIVY_EXIT_CODE /workdir"
-
-  run "$PWD/hooks/post-checkout"
-
-  assert_success
-  assert_output --partial "scanning filesystem"
-  assert_output --partial "using non-default severity types"
-  assert_output --partial "using exit-code=1 option while scanning"
+  unstub docker
+  unstub buildkite-agent
 }
 
 @test "fs scan of a test app with only vulnerbility security check" {
   export BUILDKITE_PLUGIN_TRIVY_SECURITY_CHECKS="vuln"
-  stub docker "run --rm -v $PWD/tests/testapp:/workdir  --rm aquasec/trivy:0.29.2 fs --severity $BUILDKITE_PLUGIN_TRIVY_SECURITY_CHECKS /workdir"
+  stub docker "run -v \"$PWD\":/workdir --rm $image fs --exit-code 0 --security-checks $BUILDKITE_PLUGIN_TRIVY_SECURITY_CHECKS /workdir : echo fs scan success"
+  stub buildkite-agent "annotate --style success \"trivy didn't find any relevant vulnerabilities in the repository<br />\" --context publish --append : echo fs scan success" \
+    "annotate --style success \"No container image was scanned due to a lack of an image reference. This is fine.<br />\" --context publish --append : echo no image scan happened" \
 
   run "$PWD/hooks/post-checkout"
 
   assert_success
   assert_output --partial "scanning filesystem"
-  assert_output --partial "using vuln security checks"
+  assert_output --partial "using $BUILDKITE_PLUGIN_TRIVY_SECURITY_CHECKS security checks"
+
+  unstub docker
+  unstub buildkite-agent
 }
 
 @test "fs scan of a test app with vulnerbility and configuration security check" {
-  stub docker "run --rm -v $PWD/tests/testapp:/workdir  --rm aquasec/trivy:0.29.2 fs --severity $BUILDKITE_PLUGIN_TRIVY_SECURITY_CHECKS /workdir"
+  export BUILDKITE_PLUGIN_TRIVY_SECURITY_CHECKS="vuln,config"
+  stub docker "run -v \"$PWD\":/workdir --rm $image fs --exit-code 0 --security-checks $BUILDKITE_PLUGIN_TRIVY_SECURITY_CHECKS /workdir : echo fs scan success"
+  stub buildkite-agent "annotate --style success \"trivy didn't find any relevant vulnerabilities in the repository<br />\" --context publish --append : echo fs scan success" \
+    "annotate --style success \"No container image was scanned due to a lack of an image reference. This is fine.<br />\" --context publish --append : echo no image scan happened" \
 
   run "$PWD/hooks/post-checkout"
 
   assert_success
   assert_output --partial "scanning filesystem"
-  assert_output --partial "using default security checks"
+  assert_output --partial "using $BUILDKITE_PLUGIN_TRIVY_SECURITY_CHECKS security checks"
+
+  unstub docker
+  unstub buildkite-agent
 }
 
 @test "fs scan of a test app with vulnerbility,secret and configuration security check" {
   export BUILDKITE_PLUGIN_TRIVY_SECURITY_CHECKS="vuln,secret,config"
-  stub docker "run --rm -v $PWD/tests/testapp:/workdir  --rm aquasec/trivy:0.29.2 fs --severity $BUILDKITE_PLUGIN_TRIVY_SECURITY_CHECKS /workdir"
+  stub docker "run -v \"$PWD\":/workdir --rm $image fs --exit-code 0 --security-checks $BUILDKITE_PLUGIN_TRIVY_SECURITY_CHECKS /workdir : echo fs scan success"
+  stub buildkite-agent "annotate --style success \"trivy didn't find any relevant vulnerabilities in the repository<br />\" --context publish --append : echo fs scan success" \
+    "annotate --style success \"No container image was scanned due to a lack of an image reference. This is fine.<br />\" --context publish --append : echo no image scan happened" \
 
   run "$PWD/hooks/post-checkout"
 
   assert_success
   assert_output --partial "scanning filesystem"
-  assert_output --partial "using vuln,secret,config security checks"
+  assert_output --partial "using $BUILDKITE_PLUGIN_TRIVY_SECURITY_CHECKS security checks"
+
+  unstub docker
+  unstub buildkite-agent
 }
 
-@test "scan of a test application image" {
-  export BUILDKITE_PIPELINE_ID=12345
-  export BUILDKITE_COMMIT=67890
-  export BUILDKITE_TESTING=true
+@test "scan of image reference not present locally" {
+  export BUILDKITE_PLUGIN_TRIVY_IMAGE_REF="nginx:latest"
 
-  stub docker "run --rm -v $PWD/tests/testapp:/workdir  --rm aquasec/trivy:0.29.2 image ${BUILDKITE_PIPELINE_ID}:${BUILDKITE_COMMIT}"
+  stub docker "run -v \"$PWD\":/workdir --rm $image fs --exit-code 0 --security-checks vuln,config /workdir : echo fs scan success" \
+    "images -q $BUILDKITE_PLUGIN_TRIVY_IMAGE_REF : echo ''" \
+    "pull $BUILDKITE_PLUGIN_TRIVY_IMAGE_REF : echo 'pulled image'" \
+    "run -v /var/run/docker.sock:/var/run/docker.sock --rm \"$image\" image --exit-code 0 $BUILDKITE_PLUGIN_TRIVY_IMAGE_REF : echo container image scan success"
+  stub buildkite-agent "annotate --style success \"trivy didn't find any relevant vulnerabilities in the repository<br />\" --context publish --append : echo fs scan success" \
+    "annotate --style success \"trivy didn't find any relevant vulnerabilities in the container image<br />\" --context publish --append : echo container image scan success" \
 
   run "$PWD/hooks/post-checkout"
 
   assert_success
   assert_output --partial "scanning container image"
+  assert_output --partial "pulled image"
+  assert_output --partial "container image scan success"
+
+  unstub docker
+  unstub buildkite-agent
 }
 
-@test "scan of a custom image" {
-  export BUILDKITE_PLUGIN_TRIVY_IMAGE_REF="nginx"
-  export BUILDKITE_TESTING=true
-  stub docker "run --rm -v $PWD/tests/testapp:/workdir  --rm aquasec/trivy:0.29.2 image ${BUILDKITE_PLUGIN_TRIVY_IMAGE_SCAN}"
+@test "scan of image reference present locally" {
+  export BUILDKITE_PLUGIN_TRIVY_IMAGE_REF="nginx:latest"
+
+  stub docker "run -v \"$PWD\":/workdir --rm $image fs --exit-code 0 --security-checks vuln,config /workdir : echo fs scan success" \
+    "images -q $BUILDKITE_PLUGIN_TRIVY_IMAGE_REF : echo 'Found image!'" \
+    "run -v /var/run/docker.sock:/var/run/docker.sock --rm \"$image\" image --exit-code 0 $BUILDKITE_PLUGIN_TRIVY_IMAGE_REF : echo container image scan success"
+  stub buildkite-agent "annotate --style success \"trivy didn't find any relevant vulnerabilities in the repository<br />\" --context publish --append : echo fs scan success" \
+    "annotate --style success \"trivy didn't find any relevant vulnerabilities in the container image<br />\" --context publish --append : echo container image scan success" \
 
   run "$PWD/hooks/post-checkout"
 
   assert_success
-  assert_output --partial "using image from parameters"
+  assert_output --partial "scanning container image"
+  assert_output --partial "image '$BUILDKITE_PLUGIN_TRIVY_IMAGE_REF' already present locally"
+  assert_output --partial "container image scan success"
+
+  unstub docker
+  unstub buildkite-agent
+}
+
+@test "scan of image not present locally fails" {
+  export BUILDKITE_PLUGIN_TRIVY_IMAGE_REF="nginx:latest"
+
+  stub docker "run -v \"$PWD\":/workdir --rm $image fs --exit-code 0 --security-checks vuln,config /workdir : echo fs scan success" \
+    "images -q $BUILDKITE_PLUGIN_TRIVY_IMAGE_REF : echo ''" \
+    "pull $BUILDKITE_PLUGIN_TRIVY_IMAGE_REF : echo 'pulled image'" \
+    "run -v /var/run/docker.sock:/var/run/docker.sock --rm \"$image\" image --exit-code 0 $BUILDKITE_PLUGIN_TRIVY_IMAGE_REF : exit 1"
+  stub buildkite-agent "annotate --style success \"trivy didn't find any relevant vulnerabilities in the repository<br />\" --context publish --append : echo fs scan success" \
+    "annotate --style error \"trivy found vulnerabilities in the container image. See the job output for details.<br />\" --context publish --append : echo container image scan failure" \
+
+  run "$PWD/hooks/post-checkout"
+
+  assert_failure
+  assert_output --partial "scanning container image"
+  assert_output --partial "pulled image"
+  assert_output --partial "fs scan success"
+  assert_output --partial "container image scan failure"
+
+  unstub docker
+  unstub buildkite-agent
+}
+
+@test "scan image from docker-metadata present locally" {
+  export DOCKER_METADATA_DIR="$(mktemp -d)"
+  touch "$DOCKER_METADATA_DIR/tags"
+  _TAGS_0="foo/bar:baz"
+  echo "$_TAGS_0" >> "$DOCKER_METADATA_DIR/tags"
+
+  stub docker "run -v \"$PWD\":/workdir --rm $image fs --exit-code 0 --security-checks vuln,config /workdir : echo fs scan success" \
+    "images -q $_TAGS_0 : echo 'Found image!'" \
+    "run -v /var/run/docker.sock:/var/run/docker.sock --rm \"$image\" image --exit-code 0 $_TAGS_0 : echo container image scan success"
+  stub buildkite-agent "annotate --style success \"trivy didn't find any relevant vulnerabilities in the repository<br />\" --context publish --append : echo fs scan success" \
+    "annotate --style success \"trivy didn't find any relevant vulnerabilities in the container image<br />\" --context publish --append : echo container image scan success" \
+
+  run "$PWD/hooks/post-checkout"
+
+  assert_success
+  assert_output --partial "scanning container image"
+  assert_output --partial "image '$_TAGS_0' already present locally"
+  assert_output --partial "container image scan success"
+
+  unstub docker
+  unstub buildkite-agent
+}
+
+@test "scan image from docker-metadata not present locally" {
+  export DOCKER_METADATA_DIR="$(mktemp -d)"
+  touch "$DOCKER_METADATA_DIR/tags"
+  _TAGS_0="foo/bar:baz"
+  echo "$_TAGS_0" >> "$DOCKER_METADATA_DIR/tags"
+
+  stub docker "run -v \"$PWD\":/workdir --rm $image fs --exit-code 0 --security-checks vuln,config /workdir : echo fs scan success" \
+    "images -q $_TAGS_0 : echo ''" \
+    "pull $_TAGS_0 : echo 'pulled image'" \
+    "run -v /var/run/docker.sock:/var/run/docker.sock --rm \"$image\" image --exit-code 0 $_TAGS_0 : echo container image scan success"
+  stub buildkite-agent "annotate --style success \"trivy didn't find any relevant vulnerabilities in the repository<br />\" --context publish --append : echo fs scan success" \
+    "annotate --style success \"trivy didn't find any relevant vulnerabilities in the container image<br />\" --context publish --append : echo container image scan success" \
+
+  run "$PWD/hooks/post-checkout"
+
+  assert_success
+  assert_output --partial "scanning container image"
+  assert_output --partial "pulled image"
+  assert_output --partial "container image scan success"
+
+  unstub docker
+  unstub buildkite-agent
 }


### PR DESCRIPTION
This will now only scan a container image if an image reference is
detected. This can happen if the `image_ref` parameter is passed or if
metadata from the [docker-metadata](https://github.com/equinixmetal-buildkite/docker-metadata-buildkite-plugin)
is detected.

Note that only the first image reference (tag) from the `docker-metadata`
plugin will be used, since it is assumed that all tags point to the same
image.

This also removes the ability for this plugin to build container images
if it detects a Dockerfile. This functionality should rather be left
outside of this plugin.

For better usability, this also uses the buildkite-agent command to push
a notification to users when both errors and successes happen (e.g. a
repo or image scan passed or failed).

Finally, this also extensively fixed the unit tests which were not stubbing the
docker commands correctly; Thus not actually doing relevant tests. This
now inserts mocks appropriately so we can test the behavior of the
plugin in a more extensive manner.

Related-Bug: #9 

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
