### PR TITLE
pre-checkout: Get trivy from GitHub.

### DIFF
--- a/hooks/pre-checkout
+++ b/hooks/pre-checkout
@@ -4,7 +4,7 @@
 # If it cannot locate the executable, it downloads it from GitHub,
 # authenticates it, and then copies it to one of the following directories:
 #
-# - The current working directory (default)
+# - A temporary directory
 # - ${HOME}/bin/ (if the "install-in-home-bin" option is set to "true",
 #   "TRUE", "yes", or "YES")
 #
@@ -14,7 +14,7 @@
 # available to subsequent buildkite hooks:
 #
 # - TRIVY_VERSION     - The selected trivy version
-# - TRIVY_EXE_PATH    - Set to the selected trivy executable's file path
+# - TRIVY_EXE_PATH    - The trivy executable's file path
 # - TRIVY_EXE_IN_TEMP - Set to "true" if the trivy executable is stored
 #                       in a temporary directory
 #

--- a/hooks/pre-checkout
+++ b/hooks/pre-checkout
@@ -228,13 +228,13 @@ download_trivy() {
 
   local TAR_NAME="${TAR_URL##*/}"
 
-  # Order of lines will be:
-  #   <hash-string>
-  #   <filename>
   local HASH=""
   local CURRENT_VALUE=""
   local LAST_VALUE=""
   for CURRENT_VALUE in ${HASHES}; do
+    # Order of lines will be:
+    #   <hash-string>
+    #   <filename>
     if [[ "${CURRENT_VALUE}" == "${TAR_NAME}" ]] ; then
       HASH="${LAST_VALUE}"
       break

--- a/hooks/pre-checkout
+++ b/hooks/pre-checkout
@@ -149,14 +149,19 @@ trivy_hashes_url() {
 # sha2_256_hash_file hashes the specified file using the provided
 # SHA2-256 hash string, returning status code zero on success.
 #
-# Any non-zero status code indicates an error.
+# This function exits the script with a non-zero exit status code
+# if an error occurs.
 sha2_256_hash_file() {
   local FILE="${1}"
-  [[ -z "${FILE}" ]] && return 1
-  [[ ! -f "${FILE}" ]] && return 2
+  [[ -z "${FILE}" ]] \
+    && fail_with_message "sha2_256_hash_file: file argument is missing or empty"
+
+  [[ ! -f "${FILE}" ]] \
+    && fail_with_message "sha2_256_hash_file: target file ('${FILE}') does not exist"
 
   local HASH="${2}"
-  [[ -z "${HASH}" ]] && return 3
+  [[ -z "${HASH}" ]] \
+    && fail_with_message "sha2_256_hash_file: hash argument is missing or empty"
 
   local RESULT=""
   if which sha256sum > /dev/null; then
@@ -178,13 +183,15 @@ sha2_256_hash_file() {
     RESULT="$(openssl sha256 "${FILE}")"
     RESULT="${RESULT##* }"
   else
-    return 4
+    fail_with_message "sha2_256_hash_file: no sha2-256 tool available"
   fi
 
-  [[ -z "${RESULT}" ]] && return 41
+  [[ -z "${RESULT}" ]] \
+    && fail_with_message "sha2_256_hash_file: hash result is empty"
 
   [[ "${HASH}" == "${RESULT}" ]] && return 0
 
+  fail_with_message "sha2_256_hash_file: hash mismatch: expected: '${HASH}' - got: '${RESULT}'"
   return 66
 }
 

--- a/hooks/pre-checkout
+++ b/hooks/pre-checkout
@@ -61,9 +61,6 @@ display_success() {
 #
 # For example, the string for "trivy_0.31.3_FreeBSD-32bit.tar.gz" 
 # would be "FreeBSD-32bit".
-#
-# This function exits the script with a non-zero exit status code
-# if an error occurs.
 trivy_os_cpu_string() {
   local UNAME_INFO=""
   if ! UNAME_INFO="$(uname -a)"; then
@@ -85,7 +82,6 @@ trivy_os_cpu_string() {
       ;;
     *)
       die 2 "failed to determine current computer's operating system"
-      return 1
       ;;
   esac
 
@@ -101,7 +97,6 @@ trivy_os_cpu_string() {
       ;;
     *)
       die 3 "failed to determine current computer's cpu"
-      return 2
       ;;
   esac
 
@@ -117,9 +112,6 @@ trivy_os_cpu_string() {
 #
 # For example:
 # https://github.com/aquasecurity/trivy/releases/download/v0.31.3/trivy_0.31.3_FreeBSD-64bit.tar.gz
-#
-# This function exits the script with a non-zero exit status code
-# if an error occurs.
 trivy_tar_url() {
   local VERSION="${1}"
   [[ -z "${VERSION}" ]] \
@@ -141,9 +133,6 @@ trivy_tar_url() {
 #
 # For example:
 # https://github.com/aquasecurity/trivy/releases/download/v0.31.3/trivy_0.31.3_checksums.txt
-#
-# This function exits the script with a non-zero exit status code
-# if an error occurs.
 trivy_hashes_url() {
   local VERSION="${1}"
   [[ -z "${VERSION}" ]] \
@@ -202,7 +191,6 @@ sha2_256_hash_file() {
   [[ "${HASH}" == "${RESULT}" ]] && return 0
 
   die 35 "sha2_256_hash_file: hash mismatch: expected: '${HASH}' - got: '${RESULT}'"
-  return 66
 }
 
 # download_trivy downloads the specified version of trivy from GitHub and
@@ -218,19 +206,17 @@ download_trivy() {
     && die 40 "download_trivy: trivy version not specified"
 
   local TRIVY_OS_CPU=""
-  TRIVY_OS_CPU="$(trivy_os_cpu_string)"
+  TRIVY_OS_CPU="$(trivy_os_cpu_string)" || return "${?}"
 
   local HASHES_URL=""
-  HASHES_URL="$(trivy_hashes_url "${VERSION}")"
+  HASHES_URL="$(trivy_hashes_url "${VERSION}")" || return "${?}"
 
   local TAR_URL=""
-  TAR_URL="$(trivy_tar_url "${VERSION}" "${TRIVY_OS_CPU}")"
+  TAR_URL="$(trivy_tar_url "${VERSION}" "${TRIVY_OS_CPU}")" || return "${?}"
 
   local HASHES=""
-  HASHES="$(curl --fail -L "${HASHES_URL}")"
-  # shellcheck disable=SC2181
-  [[ "${?}" -ne 0 ]] \
-    && die 41 "download_trivy: failed to download hashes"
+  HASHES="$(curl --fail -L "${HASHES_URL}")" \
+    || die 41 "download_trivy: failed to download hashes"
 
   [[ -z "${HASHES}" ]] \
     && die 42 "download_trivy: downloaded hashes file is empty"
@@ -255,17 +241,14 @@ download_trivy() {
     && die 43 "download_trivy: failed to find matching hash for '${TAR_NAME}'"
 
   local TEMP_DIR=""
-  TEMP_DIR="$(mktemp -d)"
-  # shellcheck disable=SC2181
-  [[ "${?}" -ne 0 ]] \
-    && die 44 "download_trivy: failed to create temp dir"
+  TEMP_DIR="$(mktemp -d)" || die 44 "download_trivy: failed to create temp dir"
 
   local FINAL_TAR="${TEMP_DIR}/temp-trivy.tar.gz"
   REMOVE_FILE_ON_ERR="${FINAL_TAR}"
   curl --fail -L -o "${FINAL_TAR}" "${TAR_URL}" \
     || die 45 "download_trivy: failed to download trivy to '${FINAL_TAR}'"
 
-  sha2_256_hash_file "${FINAL_TAR}" "${HASH}"
+  sha2_256_hash_file "${FINAL_TAR}" "${HASH}" || return "${?}"
 
   tar -C "${TEMP_DIR}" -xzvf "${FINAL_TAR}" \
     || die 46 "download_trivy: failed to un-tar '${FINAL_TAR}' (return code: $?)"
@@ -279,64 +262,51 @@ download_trivy() {
   return 0
 }
 
-# find_or_download_trivy searches for the trivy executable in PATH.
-# If the function does not find an executable, it installs trivy
-# from GitHub.
-find_or_download_trivy() {
-  local WHICH_TRIVY_EXE=""
-  WHICH_TRIVY_EXE="$(which trivy)"
-  # shellcheck disable=SC2181
-  if [[ "$?" -eq 0 ]] && [[ -f "${WHICH_TRIVY_EXE}" ]] ; then
-    echo "${WHICH_TRIVY_EXE}"
-    return 0
-  fi
+WHICH_TRIVY_EXE=""
+WHICH_TRIVY_EXE="$(which trivy)"
+# shellcheck disable=SC2181
+if [[ "$?" -eq 0 ]] && [[ -f "${WHICH_TRIVY_EXE}" ]]; then
+  echo "${WHICH_TRIVY_EXE}"
+  exit 0
+fi
 
-  # Note: Any error in the next function results in the script
-  # exiting with a non-zero status code.
-  local TRIVY_TMP_EXE=""
-  TRIVY_TMP_EXE="$(download_trivy "${TRIVY_VERSION}")"
+TRIVY_TMP_EXE=""
+TRIVY_TMP_EXE="$(download_trivy "${TRIVY_VERSION}")" || exit $?
 
-  # TODO: idk.
-  local HOME_INSTALL=""
-  case "${BUILDKITE_PLUGIN_TRIVY_INSTALL_IN_HOME_BIN}" in
-    "yes")
-      HOME_INSTALL=true
-      ;;
-    "YES")
-      HOME_INSTALL=true
-      ;;
-    "true")
-      HOME_INSTALL=true
-      ;;
-    "TRUE")
-      HOME_INSTALL=true
-      ;;
-  esac
+# TODO: idk.
+HOME_INSTALL=""
+case "${BUILDKITE_PLUGIN_TRIVY_INSTALL_IN_HOME_BIN}" in
+  "yes")
+    HOME_INSTALL=true
+    ;;
+  "YES")
+    HOME_INSTALL=true
+    ;;
+  "true")
+    HOME_INSTALL=true
+    ;;
+  "TRUE")
+    HOME_INSTALL=true
+    ;;
+esac
 
-  local FINAL_TRIVY_EXE=""
-  if [[ -n "${HOME_INSTALL}" ]] ; then
-    local INSTALL_DIR="${HOME}/bin"
+FINAL_TRIVY_EXE=""
+if [[ -n "${HOME_INSTALL}" ]] ; then
+  INSTALL_DIR="${HOME}/bin"
 
-    mkdir -m 0700 "${INSTALL_DIR}" \
-      || die 50 "failed to create install dir at '${INSTALL_DIR}'"
+  mkdir -m 0700 "${INSTALL_DIR}" \
+    || die 50 "failed to create install dir at '${INSTALL_DIR}'"
 
-    FINAL_TRIVY_EXE="${INSTALL_DIR}/trivy"
+  FINAL_TRIVY_EXE="${INSTALL_DIR}/trivy"
 
-    mv "${TRIVY_TMP_EXE}" "${FINAL_TRIVY_EXE}" 1> /dev/null \
-      || die 51 "failed to move '${TRIVY_TMP_EXE}' to '${FINAL_TRIVY_EXE}'"
-  else
-    export TRIVY_EXE_IN_TEMP="true"
+  mv "${TRIVY_TMP_EXE}" "${FINAL_TRIVY_EXE}" \
+    || die 51 "failed to move '${TRIVY_TMP_EXE}' to '${FINAL_TRIVY_EXE}'"
+else
+  export TRIVY_EXE_IN_TEMP="true"
 
-    FINAL_TRIVY_EXE="${TRIVY_TMP_EXE}"
-  fi
+  FINAL_TRIVY_EXE="${TRIVY_TMP_EXE}"
+fi
 
-  echo "${FINAL_TRIVY_EXE}"
+echo "${FINAL_TRIVY_EXE}"
 
-  return 0
-}
-
-TRIVY_EXE_PATH="$(find_or_download_trivy)"
-
-echo "${TRIVY_EXE_PATH}"
-
-export TRIVY_EXE_PATH
+export TRIVY_EXE_PATH="${FINAL_TRIVY_EXE}"

--- a/hooks/pre-checkout
+++ b/hooks/pre-checkout
@@ -40,7 +40,7 @@ REMOVE_FILE_ON_ERR=""
 die() {
   [[ -f "${REMOVE_FILE_ON_ERR}" ]] && rm "${REMOVE_FILE_ON_ERR}"
   display_error "$2"
-  exit $1
+  exit "$1"
 }
 
 display_error() {

--- a/hooks/pre-checkout
+++ b/hooks/pre-checkout
@@ -25,7 +25,7 @@
 # - which
 # - mkdir
 
-export TRIVY_DEFAULT_VERSION="0.29.2"
+readonly TRIVY_DEFAULT_VERSION="0.29.2"
 export TRIVY_VERSION="${BUILDKITE_PLUGIN_TRIVY_VERSION:-$TRIVY_DEFAULT_VERSION}"
 
 fail_with_message() {

--- a/hooks/pre-checkout
+++ b/hooks/pre-checkout
@@ -218,11 +218,14 @@ download_trivy() {
   [[ -z "${VERSION}" ]] \
     && fail_with_message "download_trivy: trivy version not specified"
 
-  local TRIVY_OS_CPU="$(trivy_os_cpu_string)"
+  local TRIVY_OS_CPU=""
+  TRIVY_OS_CPU="$(trivy_os_cpu_string)"
 
-  local HASHES_URL="$(trivy_hashes_url "${VERSION}")"
+  local HASHES_URL=""
+  HASHES_URL="$(trivy_hashes_url "${VERSION}")"
 
-  local TAR_URL=$(trivy_tar_url "${VERSION}" "${TRIVY_OS_CPU}")
+  local TAR_URL=""
+  TAR_URL="$(trivy_tar_url "${VERSION}" "${TRIVY_OS_CPU}")"
 
   local HASHES=""
   HASHES="$(curl --fail -L "${HASHES_URL}")"

--- a/hooks/pre-checkout
+++ b/hooks/pre-checkout
@@ -175,10 +175,10 @@ sha2_256_hash_file() {
 }
 
 # download_trivy downloads the specified version of trivy from GitHub and
-# authenticates it using the hashes file stored with the GitHub # release
+# authenticates it using the hashes file stored with the GitHub release
 # (yes, this is not ideal). Callers can also specify an optional file
-# path to move the executable to. If no file path is specified, the function
-# leaves the executable in a temporary directory.
+# path to move the executable to. If no file path is specified, the
+# function leaves the executable in a temporary directory.
 #
 # The function writes the executable's final file path to stdout.
 download_trivy() {

--- a/hooks/pre-checkout
+++ b/hooks/pre-checkout
@@ -107,12 +107,17 @@ trivy_os_cpu_string() {
 #
 # For example:
 # https://github.com/aquasecurity/trivy/releases/download/v0.31.3/trivy_0.31.3_FreeBSD-64bit.tar.gz
+#
+# This function exits the script with a non-zero exit status code
+# if an error occurs.
 trivy_tar_url() {
   local VERSION="${1}"
-  [[ -z "${VERSION}" ]] && return 1
+  [[ -z "${VERSION}" ]] \
+    && fail_with_message "trivy_tar_url: version argument is missing or empty"
 
   local OS_CPU="${2}"
-  [[ -z "${OS_CPU}" ]] && return 2
+  [[ -z "${OS_CPU}" ]] \
+    && fail_with_message "trivy_tar_url: os-cpu string argument is missing or empty"
 
   local BASE_URL="https://github.com/aquasecurity/trivy/releases/download"
   local URL="${BASE_URL}/v${VERSION}/trivy_${VERSION}_${OS_CPU}.tar.gz"
@@ -124,13 +129,15 @@ trivy_tar_url() {
 # trivy_hashes_url builds the hashes URL for the specified version
 # of trivy and writes it to stdout.
 #
-# Any non-zero status code indicates an error.
-#
 # For example:
 # https://github.com/aquasecurity/trivy/releases/download/v0.31.3/trivy_0.31.3_checksums.txt
+#
+# This function exits the script with a non-zero exit status code
+# if an error occurs.
 trivy_hashes_url() {
   local VERSION="${1}"
-  [[ -z "${VERSION}" ]] && return 1
+  [[ -z "${VERSION}" ]] \
+    && fail_with_message "trivy_hashes_url: version argument is missing or empty"
 
   local BASE_URL="https://github.com/aquasecurity/trivy/releases/download"
   local URL="${BASE_URL}/v${VERSION}/trivy_${VERSION}_checksums.txt"

--- a/hooks/pre-checkout
+++ b/hooks/pre-checkout
@@ -37,11 +37,10 @@ readonly TRIVY_DEFAULT_VERSION="0.29.2"
 export TRIVY_VERSION="${BUILDKITE_PLUGIN_TRIVY_VERSION:-$TRIVY_DEFAULT_VERSION}"
 REMOVE_FILE_ON_ERR=""
 
-# TODO: Accept exit code as function argument.
-fail_with_message() {
+die() {
   [[ -f "${REMOVE_FILE_ON_ERR}" ]] && rm "${REMOVE_FILE_ON_ERR}"
-  display_error "$1"
-  exit 1
+  display_error "$2"
+  exit $1
 }
 
 display_error() {
@@ -68,7 +67,7 @@ display_success() {
 trivy_os_cpu_string() {
   local UNAME_INFO=""
   if ! UNAME_INFO="$(uname -a)"; then
-    fail_with_message "failed to run uname"
+    die 1 "failed to run uname"
   fi
 
   local RUNTIME_OS=""
@@ -85,7 +84,7 @@ trivy_os_cpu_string() {
       RUNTIME_OS=FreeBSD
       ;;
     *)
-      fail_with_message "failed to determine current computer's operating system"
+      die 2 "failed to determine current computer's operating system"
       return 1
       ;;
   esac
@@ -101,7 +100,7 @@ trivy_os_cpu_string() {
       RUNTIME_CPU=ARM64
       ;;
     *)
-      fail_with_message "failed to determine current computer's cpu"
+      die 3 "failed to determine current computer's cpu"
       return 2
       ;;
   esac
@@ -124,11 +123,11 @@ trivy_os_cpu_string() {
 trivy_tar_url() {
   local VERSION="${1}"
   [[ -z "${VERSION}" ]] \
-    && fail_with_message "trivy_tar_url: version argument is missing or empty"
+    && die 10 "trivy_tar_url: version argument is missing or empty"
 
   local OS_CPU="${2}"
   [[ -z "${OS_CPU}" ]] \
-    && fail_with_message "trivy_tar_url: os-cpu string argument is missing or empty"
+    && die 11 "trivy_tar_url: os-cpu string argument is missing or empty"
 
   local BASE_URL="https://github.com/aquasecurity/trivy/releases/download"
   local URL="${BASE_URL}/v${VERSION}/trivy_${VERSION}_${OS_CPU}.tar.gz"
@@ -148,7 +147,7 @@ trivy_tar_url() {
 trivy_hashes_url() {
   local VERSION="${1}"
   [[ -z "${VERSION}" ]] \
-    && fail_with_message "trivy_hashes_url: version argument is missing or empty"
+    && die 20 "trivy_hashes_url: version argument is missing or empty"
 
   local BASE_URL="https://github.com/aquasecurity/trivy/releases/download"
   local URL="${BASE_URL}/v${VERSION}/trivy_${VERSION}_checksums.txt"
@@ -165,14 +164,14 @@ trivy_hashes_url() {
 sha2_256_hash_file() {
   local FILE="${1}"
   [[ -z "${FILE}" ]] \
-    && fail_with_message "sha2_256_hash_file: file argument is missing or empty"
+    && die 30 "sha2_256_hash_file: file argument is missing or empty"
 
   [[ ! -f "${FILE}" ]] \
-    && fail_with_message "sha2_256_hash_file: target file ('${FILE}') does not exist"
+    && die 31 "sha2_256_hash_file: target file ('${FILE}') does not exist"
 
   local HASH="${2}"
   [[ -z "${HASH}" ]] \
-    && fail_with_message "sha2_256_hash_file: hash argument is missing or empty"
+    && die 32 "sha2_256_hash_file: hash argument is missing or empty"
 
   local RESULT=""
   if which sha256sum > /dev/null; then
@@ -194,15 +193,15 @@ sha2_256_hash_file() {
     RESULT="$(openssl sha256 "${FILE}")"
     RESULT="${RESULT##* }"
   else
-    fail_with_message "sha2_256_hash_file: no sha2-256 tool available"
+    die 33 "sha2_256_hash_file: no sha2-256 tool available"
   fi
 
   [[ -z "${RESULT}" ]] \
-    && fail_with_message "sha2_256_hash_file: hash result is empty"
+    && die 34 "sha2_256_hash_file: hash result is empty"
 
   [[ "${HASH}" == "${RESULT}" ]] && return 0
 
-  fail_with_message "sha2_256_hash_file: hash mismatch: expected: '${HASH}' - got: '${RESULT}'"
+  die 35 "sha2_256_hash_file: hash mismatch: expected: '${HASH}' - got: '${RESULT}'"
   return 66
 }
 
@@ -216,7 +215,7 @@ sha2_256_hash_file() {
 download_trivy() {
   local VERSION="${1}"
   [[ -z "${VERSION}" ]] \
-    && fail_with_message "download_trivy: trivy version not specified"
+    && die 40 "download_trivy: trivy version not specified"
 
   local TRIVY_OS_CPU=""
   TRIVY_OS_CPU="$(trivy_os_cpu_string)"
@@ -230,10 +229,10 @@ download_trivy() {
   local HASHES=""
   HASHES="$(curl --fail -L "${HASHES_URL}")"
   [[ "${?}" -ne 0 ]] \
-    && fail_with_message "download_trivy: failed to download hashes"
+    && die 41 "download_trivy: failed to download hashes"
 
   [[ -z "${HASHES}" ]] \
-    && fail_with_message "download_trivy: downloaded hashes file is empty"
+    && die 42 "download_trivy: downloaded hashes file is empty"
 
   local TAR_NAME="${TAR_URL##*/}"
 
@@ -252,26 +251,26 @@ download_trivy() {
   done
 
   [[ -z "${HASH}" ]] \
-    && fail_with_message "download_trivy: failed to find matching hash for '${TAR_NAME}'"
+    && die 43 "download_trivy: failed to find matching hash for '${TAR_NAME}'"
 
   local TEMP_DIR=""
   TEMP_DIR="$(mktemp -d)"
   [[ "${?}" -ne 0 ]] \
-    && fail_with_message "download_trivy: failed to create temp dir"
+    && die 44 "download_trivy: failed to create temp dir"
 
   local FINAL_TAR="${TEMP_DIR}/temp-trivy.tar.gz"
   REMOVE_FILE_ON_ERR="${FINAL_TAR}"
   curl --fail -L -o "${FINAL_TAR}" "${TAR_URL}" \
-    || fail_with_message "download_trivy: failed to download trivy to '${FINAL_TAR}'"
+    || die 45 "download_trivy: failed to download trivy to '${FINAL_TAR}'"
 
   sha2_256_hash_file "${FINAL_TAR}" "${HASH}"
 
   tar -C "${TEMP_DIR}" -xzvf "${FINAL_TAR}" \
-    || fail_with_message "download_trivy: failed to un-tar '${FINAL_TAR}' (return code: $?)"
+    || die 46 "download_trivy: failed to un-tar '${FINAL_TAR}' (return code: $?)"
 
   local EXE="${TEMP_DIR}/trivy"
   [[ -f "${EXE}" ]] \
-    || fail_with_message "download_trivy: '${TAR_NAME}' does not contain a file named 'trivy'"
+    || die 47 "download_trivy: '${TAR_NAME}' does not contain a file named 'trivy'"
 
   echo "${EXE}"
 
@@ -316,12 +315,12 @@ find_or_download_trivy() {
     local INSTALL_DIR="${HOME}/bin"
 
     mkdir -m 0700 "${INSTALL_DIR}" \
-      || fail_with_message "failed to create install dir at '${INSTALL_DIR}'"
+      || die 50 "failed to create install dir at '${INSTALL_DIR}'"
 
     FINAL_TRIVY_EXE="${INSTALL_DIR}/trivy"
 
     mv "${TRIVY_TMP_EXE}" "${FINAL_TRIVY_EXE}" 1> /dev/null \
-      || fail_with_message "failed to move '${TRIVY_TMP_EXE}' to '${FINAL_TRIVY_EXE}'"
+      || die 51 "failed to move '${TRIVY_TMP_EXE}' to '${FINAL_TRIVY_EXE}'"
   else
     export TRIVY_EXE_IN_TEMP="true"
 

--- a/hooks/pre-checkout
+++ b/hooks/pre-checkout
@@ -228,6 +228,7 @@ download_trivy() {
 
   local HASHES=""
   HASHES="$(curl --fail -L "${HASHES_URL}")"
+  # shellcheck disable=SC2181
   [[ "${?}" -ne 0 ]] \
     && die 41 "download_trivy: failed to download hashes"
 
@@ -255,6 +256,7 @@ download_trivy() {
 
   local TEMP_DIR=""
   TEMP_DIR="$(mktemp -d)"
+  # shellcheck disable=SC2181
   [[ "${?}" -ne 0 ]] \
     && die 44 "download_trivy: failed to create temp dir"
 
@@ -283,6 +285,7 @@ download_trivy() {
 find_or_download_trivy() {
   local WHICH_TRIVY_EXE=""
   WHICH_TRIVY_EXE="$(which trivy)"
+  # shellcheck disable=SC2181
   if [[ "$?" -eq 0 ]] && [[ -f "${WHICH_TRIVY_EXE}" ]] ; then
     echo "${WHICH_TRIVY_EXE}"
     return 0

--- a/hooks/pre-checkout
+++ b/hooks/pre-checkout
@@ -51,8 +51,15 @@ display_success() {
 #
 # For example, the string for "trivy_0.31.3_FreeBSD-32bit.tar.gz" 
 # would be "FreeBSD-32bit".
+#
+# This function exits the script with a non-zero exit status code
+# if an error occurs.
 trivy_os_cpu_string() {
-  local UNAME_INFO="$(uname -a)"
+  local UNAME_INFO=""
+  if ! UNAME_INFO="$(uname -a)"; then
+    fail_with_message "failed to run uname"
+  fi
+
   local RUNTIME_OS=""
   local RUNTIME_CPU=""
 

--- a/hooks/pre-checkout
+++ b/hooks/pre-checkout
@@ -145,7 +145,7 @@ sha2_256_hash_file() {
   [[ -z "${HASH}" ]] && return 3
 
   local RESULT=""
-  if which sha256sum 2>&1 > /dev/null; then
+  if which sha256sum > /dev/null; then
     # $ RESULT="$(sha256sum /proc/self/cmdline)"
     # $ echo "${RESULT}"
     # 31d14183b4... /proc/self/cmdline
@@ -154,7 +154,7 @@ sha2_256_hash_file() {
     # 31d14183b4...
     RESULT="$(sha256sum "${FILE}")"
     RESULT="${RESULT% *}"
-  elif which openssl 2>&1 > /dev/null; then
+  elif which openssl > /dev/null; then
     # $ RESULT="$(openssl sha256 /proc/self/cmdline)"
     # $ echo "${RESULT}"
     # SHA256(/proc/self/cmdline)= fbc0b267807d5d...

--- a/hooks/pre-checkout
+++ b/hooks/pre-checkout
@@ -1,0 +1,296 @@
+#!/bin/bash
+
+# This portion of the plugin looks for the "trivy" executable in PATH.
+# If it cannot locate the executable, it downloads it from GitHub,
+# authenticates it, and then copies it to one of the following directories:
+#
+# - The current working directory (default)
+# - ${HOME}/bin/ (if the "install-in-home-bin" option is set to "true",
+#   "TRUE", "yes", or "YES")
+#
+# The script then writes the executable's file path to stdout.
+#
+# Required executables / bash built-ins:
+#
+# - exit
+# - echo
+# - export
+# - if / [[ ]]
+# - buildkite-agent
+# - uname
+# - curl
+# - sha256sum || openssl
+# - mktemp
+# - tar
+# - which
+# - mkdir
+
+export TRIVY_DEFAULT_VERSION="0.29.2"
+export TRIVY_VERSION="${BUILDKITE_PLUGIN_TRIVY_VERSION:-$TRIVY_DEFAULT_VERSION}"
+
+fail_with_message() {
+  display_error "$1"
+  exit 1
+}
+
+display_error() {
+  message="$1"
+  echo "🚨 $message" >&2
+  buildkite-agent annotate --style error "$message<br />" --context publish --append
+}
+
+display_success() {
+  message="$1"
+  echo "$message"
+  buildkite-agent annotate --style success "$message<br />" --context publish --append
+}
+
+# trivy_os_cpu_string retrieves information from the runtime
+# environment and uses it to build the OS and CPU string that
+# appears in each trivy release's file name.
+#
+# For example, the string for "trivy_0.31.3_FreeBSD-32bit.tar.gz" 
+# would be "FreeBSD-32bit".
+trivy_os_cpu_string() {
+  local UNAME_INFO="$(uname -a)"
+  local RUNTIME_OS=""
+  local RUNTIME_CPU=""
+
+  case "${UNAME_INFO}" in
+    *Darwin*)
+      RUNTIME_OS=macOS
+      ;;
+    *Linux*)
+      RUNTIME_OS=Linux
+      ;;
+    *FreeBSD*)
+      RUNTIME_OS=FreeBSD
+      ;;
+    *)
+      fail_with_message "failed to determine current computer's operating system"
+      return 1
+      ;;
+  esac
+
+  case "${UNAME_INFO}" in
+    *amd64*)
+      RUNTIME_CPU=64bit
+      ;;
+    *x86_64*)
+      RUNTIME_CPU=64bit
+      ;;
+    *arm64*)
+      RUNTIME_CPU=ARM64
+      ;;
+    *)
+      fail_with_message "failed to determine current computer's cpu"
+      return 2
+      ;;
+  esac
+
+  echo "${RUNTIME_OS}-${RUNTIME_CPU}"
+
+  return 0
+}
+
+# trivy_tar_url builds the tar.gz URL for the specified version
+# of trivy and writes it to stdout.
+#
+# Any non-zero status code indicates an error.
+#
+# For example:
+# https://github.com/aquasecurity/trivy/releases/download/v0.31.3/trivy_0.31.3_FreeBSD-64bit.tar.gz
+trivy_tar_url() {
+  local VERSION="${1}"
+  [[ -z "${VERSION}" ]] && return 1
+
+  local OS_CPU="${2}"
+  [[ -z "${OS_CPU}" ]] && return 2
+
+  local BASE_URL="https://github.com/aquasecurity/trivy/releases/download"
+  local URL="${BASE_URL}/v${VERSION}/trivy_${VERSION}_${OS_CPU}.tar.gz"
+
+  echo "${URL}"
+  return 0
+}
+
+# trivy_hashes_url builds the hashes URL for the specified version
+# of trivy and writes it to stdout.
+#
+# Any non-zero status code indicates an error.
+#
+# For example:
+# https://github.com/aquasecurity/trivy/releases/download/v0.31.3/trivy_0.31.3_checksums.txt
+trivy_hashes_url() {
+  local VERSION="${1}"
+  [[ -z "${VERSION}" ]] && return 1
+
+  local BASE_URL="https://github.com/aquasecurity/trivy/releases/download"
+  local URL="${BASE_URL}/v${VERSION}/trivy_${VERSION}_checksums.txt"
+
+  echo "${URL}"
+  return 0
+}
+
+# sha2_256_hash_file hashes the specified file using the provided
+# SHA2-256 hash string, returning status code zero on success.
+#
+# Any non-zero status code indicates an error.
+sha2_256_hash_file() {
+  local FILE="${1}"
+  [[ -z "${FILE}" ]] && return 1
+  [[ ! -f "${FILE}" ]] && return 2
+
+  local HASH="${2}"
+  [[ -z "${HASH}" ]] && return 3
+
+  local RESULT=""
+  if which sha256sum 2>&1 > /dev/null; then
+    # $ RESULT="$(sha256sum /proc/self/cmdline)"
+    # $ echo "${RESULT}"
+    # 31d14183b4... /proc/self/cmdline
+    # $ RESULT="${RESULT% *}"
+    # $ echo "${RESULT}"
+    # 31d14183b4...
+    RESULT="$(sha256sum "${FILE}")"
+    RESULT="${RESULT% *}"
+  elif which openssl 2>&1 > /dev/null; then
+    # $ RESULT="$(openssl sha256 /proc/self/cmdline)"
+    # $ echo "${RESULT}"
+    # SHA256(/proc/self/cmdline)= fbc0b267807d5d...
+    # $ RESULT="${RESULT##* }"
+    # $ echo "${RESULT}"
+    # fbc0b267807d5d...
+    RESULT="$(openssl sha256 "${FILE}")"
+    RESULT="${RESULT##* }"
+  else
+    return 4
+  fi
+
+  [[ -z "${RESULT}" ]] && return 41
+
+  [[ "${HASH}" == "${RESULT}" ]] && return 0
+
+  return 66
+}
+
+# download_trivy downloads the specified version of trivy from GitHub and
+# authenticates it using the hashes file stored with the GitHub # release
+# (yes, this is not ideal). Callers can also specify an optional file
+# path to move the executable to. If no file path is specified, the function
+# leaves the executable in a temporary directory.
+#
+# The function writes the executable's final file path to stdout.
+download_trivy() {
+  local VERSION="${1}"
+  [[ -z "${VERSION}" ]] \
+    && fail_with_message "download_trivy: trivy version not specified"
+
+  local OPTIONAL_DEST="${2}"
+
+  local TRIVY_OS_CPU="$(trivy_os_cpu_string)"
+
+  local HASHES_URL="$(trivy_hashes_url "${VERSION}")"
+  [[ "${?}" -ne 0 ]] \
+    && fail_with_message "download_trivy: failed to create hashes url"
+
+  local TAR_URL=$(trivy_tar_url "${VERSION}" "${TRIVY_OS_CPU}")
+  [[ "${?}" -ne 0 ]] \
+    && fail_with_message "download_trivy: failed to create tar url"
+
+  local HASHES="$(curl --fail -L "${HASHES_URL}")"
+  [[ "${?}" -ne 0 ]] \
+    && fail_with_message "download_trivy: failed to download hashes"
+
+  [[ -z "${HASHES}" ]] \
+    && fail_with_message "download_trivy: downloaded hashes file is empty"
+
+  local TAR_NAME="${TAR_URL##*/}"
+
+  # Order of lines will be:
+  #   <hash-string>
+  #   <filename>
+  local HASH=""
+  local CURRENT_VALUE=""
+  local LAST_VALUE=""
+  for CURRENT_VALUE in ${HASHES}; do
+    if [[ "${CURRENT_VALUE}" == "${TAR_NAME}" ]] ; then
+      HASH="${LAST_VALUE}"
+      break
+    fi
+    LAST_VALUE="${CURRENT_VALUE}"
+  done
+
+  [[ -z "${HASH}" ]] \
+    && fail_with_message "download_trivy: failed to find matching hash for '${TAR_NAME}'"
+
+  local TEMP_DIR="$(mktemp -d)"
+  [[ "${?}" -ne 0 ]] \
+    && fail_with_message "download_trivy: failed to create temp dir"
+
+  local FINAL_TAR="${TEMP_DIR}/temp-trivy.tar.gz"
+  curl --fail -L -o "${FINAL_TAR}" "${TAR_URL}" \
+    || fail_with_message "download_trivy: failed to download trivy to '${FINAL_TAR}'"
+
+  sha2_256_hash_file "${FINAL_TAR}" "${HASH}" \
+    || fail_with_message "download_trivy: failed to verify '${FINAL_TAR}' (return code: $?)"
+
+  tar -C "${TEMP_DIR}" -xzvf "${FINAL_TAR}" \
+    || fail_with_message "download_trivy: failed to un-tar '${FINAL_TAR}' (return code: $?)"
+
+  local TRIVY_EXE="${TEMP_DIR}/trivy"
+  [[ -f "${TRIVY_EXE}" ]] \
+    || fail_with_message "download_trivy: '${TAR_NAME}' should contain a file named 'trivy' - it does not"
+
+  if [[ -z "${OPTIONAL_DEST}" ]] ; then
+    echo "${TRIVY_EXE}"
+    return 0
+  fi
+
+  mv -v "${TRIVY_EXE}" "${OPTIONAL_DEST}" \
+    || fail_with_message "download_trivy: failed to move '${TRIVY_EXE}' to '${OPTIONAL_DEST}'"
+
+  return 0
+}
+
+# find_or_download_trivy searches for the trivy executable in PATH.
+# If the function does not find an executable, it installs trivy
+# from GitHub.
+find_or_download_trivy() {
+  local TRIVY_EXE="$(which trivy)"
+  if [[ "$?" -eq 0 ]] && [[ -f "${TRIVY_EXE}" ]] ; then
+    echo "${TRIVY_EXE}"
+    return 0
+  fi
+
+  # TODO: idk.
+  local INSTALL_DIR="${PWD}"
+  local HOME_INSTALL=""
+  case "${BUILDKITE_PLUGIN_TRIVY_INSTALL_IN_HOME_BIN}" in
+    "yes")
+      HOME_INSTALL=true
+      ;;
+    "YES")
+      HOME_INSTALL=true
+      ;;
+    "true")
+      HOME_INSTALL=true
+      ;;
+    "TRUE")
+      HOME_INSTALL=true
+      ;;
+  esac
+
+  if [[ -n "${HOME_INSTALL}" ]] ; then
+    INSTALL_DIR="${HOME}/bin"
+    mkdir -m 0700 "${INSTALL_DIR}" \
+      || fail_with_message "failed to create install dir at '${INSTALL_DIR}'"
+  fi
+
+  # Note: Any error in the next function results in the script
+  # exiting with a non-zero status code.
+  echo "$(download_trivy "${TRIVY_VERSION}" "${INSTALL_DIR}/trivy")"
+  return 0
+}
+
+find_or_download_trivy

--- a/hooks/pre-checkout
+++ b/hooks/pre-checkout
@@ -10,6 +10,14 @@
 #
 # The script then writes the executable's file path to stdout.
 #
+# The following environment variables are set and (theoretically)
+# available to subsequent buildkite hooks:
+#
+# - TRIVY_VERSION     - The selected trivy version
+# - TRIVY_EXE_PATH    - Set to the selected trivy executable's file path
+# - TRIVY_EXE_IN_TEMP - Set to "true" if the trivy executable is stored
+#                       in a temporary directory
+#
 # Required executables / bash built-ins:
 #
 # - exit
@@ -27,8 +35,11 @@
 
 readonly TRIVY_DEFAULT_VERSION="0.29.2"
 export TRIVY_VERSION="${BUILDKITE_PLUGIN_TRIVY_VERSION:-$TRIVY_DEFAULT_VERSION}"
+REMOVE_FILE_ON_ERR=""
 
+# TODO: Accept exit code as function argument.
 fail_with_message() {
+  [[ -f "${REMOVE_FILE_ON_ERR}" ]] && rm "${REMOVE_FILE_ON_ERR}"
   display_error "$1"
   exit 1
 }
@@ -197,29 +208,24 @@ sha2_256_hash_file() {
 
 # download_trivy downloads the specified version of trivy from GitHub and
 # authenticates it using the hashes file stored with the GitHub release
-# (yes, this is not ideal). Callers can also specify an optional file
-# path to move the executable to. If no file path is specified, the
-# function leaves the executable in a temporary directory.
+# (yes, this is not ideal). The function saves the executable in a temporary
+# directory. The trivy executable's file path is written to stdout.
 #
-# The function writes the executable's final file path to stdout.
+# This function exits the script with a non-zero exit status code
+# if an error occurs.
 download_trivy() {
   local VERSION="${1}"
   [[ -z "${VERSION}" ]] \
     && fail_with_message "download_trivy: trivy version not specified"
 
-  local OPTIONAL_DEST="${2}"
-
   local TRIVY_OS_CPU="$(trivy_os_cpu_string)"
 
   local HASHES_URL="$(trivy_hashes_url "${VERSION}")"
-  [[ "${?}" -ne 0 ]] \
-    && fail_with_message "download_trivy: failed to create hashes url"
 
   local TAR_URL=$(trivy_tar_url "${VERSION}" "${TRIVY_OS_CPU}")
-  [[ "${?}" -ne 0 ]] \
-    && fail_with_message "download_trivy: failed to create tar url"
 
-  local HASHES="$(curl --fail -L "${HASHES_URL}")"
+  local HASHES=""
+  HASHES="$(curl --fail -L "${HASHES_URL}")"
   [[ "${?}" -ne 0 ]] \
     && fail_with_message "download_trivy: failed to download hashes"
 
@@ -245,31 +251,26 @@ download_trivy() {
   [[ -z "${HASH}" ]] \
     && fail_with_message "download_trivy: failed to find matching hash for '${TAR_NAME}'"
 
-  local TEMP_DIR="$(mktemp -d)"
+  local TEMP_DIR=""
+  TEMP_DIR="$(mktemp -d)"
   [[ "${?}" -ne 0 ]] \
     && fail_with_message "download_trivy: failed to create temp dir"
 
   local FINAL_TAR="${TEMP_DIR}/temp-trivy.tar.gz"
+  REMOVE_FILE_ON_ERR="${FINAL_TAR}"
   curl --fail -L -o "${FINAL_TAR}" "${TAR_URL}" \
     || fail_with_message "download_trivy: failed to download trivy to '${FINAL_TAR}'"
 
-  sha2_256_hash_file "${FINAL_TAR}" "${HASH}" \
-    || fail_with_message "download_trivy: failed to verify '${FINAL_TAR}' (return code: $?)"
+  sha2_256_hash_file "${FINAL_TAR}" "${HASH}"
 
   tar -C "${TEMP_DIR}" -xzvf "${FINAL_TAR}" \
     || fail_with_message "download_trivy: failed to un-tar '${FINAL_TAR}' (return code: $?)"
 
-  local TRIVY_EXE="${TEMP_DIR}/trivy"
-  [[ -f "${TRIVY_EXE}" ]] \
-    || fail_with_message "download_trivy: '${TAR_NAME}' should contain a file named 'trivy' - it does not"
+  local EXE="${TEMP_DIR}/trivy"
+  [[ -f "${EXE}" ]] \
+    || fail_with_message "download_trivy: '${TAR_NAME}' does not contain a file named 'trivy'"
 
-  if [[ -z "${OPTIONAL_DEST}" ]] ; then
-    echo "${TRIVY_EXE}"
-    return 0
-  fi
-
-  mv -v "${TRIVY_EXE}" "${OPTIONAL_DEST}" \
-    || fail_with_message "download_trivy: failed to move '${TRIVY_EXE}' to '${OPTIONAL_DEST}'"
+  echo "${EXE}"
 
   return 0
 }
@@ -278,14 +279,19 @@ download_trivy() {
 # If the function does not find an executable, it installs trivy
 # from GitHub.
 find_or_download_trivy() {
-  local TRIVY_EXE="$(which trivy)"
-  if [[ "$?" -eq 0 ]] && [[ -f "${TRIVY_EXE}" ]] ; then
-    echo "${TRIVY_EXE}"
+  local WHICH_TRIVY_EXE=""
+  WHICH_TRIVY_EXE="$(which trivy)"
+  if [[ "$?" -eq 0 ]] && [[ -f "${WHICH_TRIVY_EXE}" ]] ; then
+    echo "${WHICH_TRIVY_EXE}"
     return 0
   fi
 
+  # Note: Any error in the next function results in the script
+  # exiting with a non-zero status code.
+  local TRIVY_TMP_EXE=""
+  TRIVY_TMP_EXE="$(download_trivy "${TRIVY_VERSION}")"
+
   # TODO: idk.
-  local INSTALL_DIR="${PWD}"
   local HOME_INSTALL=""
   case "${BUILDKITE_PLUGIN_TRIVY_INSTALL_IN_HOME_BIN}" in
     "yes")
@@ -302,16 +308,30 @@ find_or_download_trivy() {
       ;;
   esac
 
+  local FINAL_TRIVY_EXE=""
   if [[ -n "${HOME_INSTALL}" ]] ; then
-    INSTALL_DIR="${HOME}/bin"
+    local INSTALL_DIR="${HOME}/bin"
+
     mkdir -m 0700 "${INSTALL_DIR}" \
       || fail_with_message "failed to create install dir at '${INSTALL_DIR}'"
+
+    FINAL_TRIVY_EXE="${INSTALL_DIR}/trivy"
+
+    mv "${TRIVY_TMP_EXE}" "${FINAL_TRIVY_EXE}" 1> /dev/null \
+      || fail_with_message "failed to move '${TRIVY_TMP_EXE}' to '${FINAL_TRIVY_EXE}'"
+  else
+    export TRIVY_EXE_IN_TEMP="true"
+
+    FINAL_TRIVY_EXE="${TRIVY_TMP_EXE}"
   fi
 
-  # Note: Any error in the next function results in the script
-  # exiting with a non-zero status code.
-  echo "$(download_trivy "${TRIVY_VERSION}" "${INSTALL_DIR}/trivy")"
+  echo "${FINAL_TRIVY_EXE}"
+
   return 0
 }
 
-find_or_download_trivy
+TRIVY_EXE_PATH="$(find_or_download_trivy)"
+
+echo "${TRIVY_EXE_PATH}"
+
+export TRIVY_EXE_PATH

--- a/hooks/pre-checkout
+++ b/hooks/pre-checkout
@@ -108,8 +108,6 @@ trivy_os_cpu_string() {
 # trivy_tar_url builds the tar.gz URL for the specified version
 # of trivy and writes it to stdout.
 #
-# Any non-zero status code indicates an error.
-#
 # For example:
 # https://github.com/aquasecurity/trivy/releases/download/v0.31.3/trivy_0.31.3_FreeBSD-64bit.tar.gz
 trivy_tar_url() {
@@ -145,11 +143,9 @@ trivy_hashes_url() {
   return 0
 }
 
-# sha2_256_hash_file hashes the specified file using the provided
-# SHA2-256 hash string, returning status code zero on success.
-#
-# This function exits the script with a non-zero exit status code
-# if an error occurs.
+# sha2_256_hash_file hashes the specified file and compares the resulting
+# hash with the provided SHA2-256 hash string, returning status code zero
+# on success.
 sha2_256_hash_file() {
   local FILE="${1}"
   [[ -z "${FILE}" ]] \
@@ -197,9 +193,6 @@ sha2_256_hash_file() {
 # authenticates it using the hashes file stored with the GitHub release
 # (yes, this is not ideal). The function saves the executable in a temporary
 # directory. The trivy executable's file path is written to stdout.
-#
-# This function exits the script with a non-zero exit status code
-# if an error occurs.
 download_trivy() {
   local VERSION="${1}"
   [[ -z "${VERSION}" ]] \
@@ -251,7 +244,7 @@ download_trivy() {
   sha2_256_hash_file "${FINAL_TAR}" "${HASH}" || return "${?}"
 
   tar -C "${TEMP_DIR}" -xzvf "${FINAL_TAR}" \
-    || die 46 "download_trivy: failed to un-tar '${FINAL_TAR}' (return code: $?)"
+    || die 46 "download_trivy: failed to un-tar '${FINAL_TAR}'"
 
   local EXE="${TEMP_DIR}/trivy"
   [[ -f "${EXE}" ]] \

--- a/plugin.yml
+++ b/plugin.yml
@@ -4,6 +4,10 @@ author: Hari
 requirements:
   - bash
   - docker
+  - uname
+  - curl
+  - mktemp
+  - tar
 configuration:
   properties:
     exit-code:

--- a/tests/pre-checkout.bats
+++ b/tests/pre-checkout.bats
@@ -1,0 +1,81 @@
+#!/usr/bin/env bats
+
+load '/usr/local/lib/bats/load.bash'
+
+# Uncomment the following line to debug stub failures
+# export BUILDKITE_AGENT_STUB_DEBUG=/dev/tty
+
+setup() {
+  stub buildkite-agent "* : exit 0"
+}
+
+teardown() {
+  unstub buildkite-agent
+}
+
+@test "trivy_os_cpu_string: uname failure" {
+  stub uname "-a : exit 123"
+
+  run "$PWD/hooks/pre-checkout"
+
+  [ "$status" -eq 1 ]
+
+  unstub uname
+}
+
+@test "trivy_os_cpu_string: unknown os" {
+  stub uname "-a : echo foobar"
+
+  run "$PWD/hooks/pre-checkout"
+
+  [ "$status" -eq 2 ]
+
+  unstub uname
+}
+
+@test "trivy_os_cpu_string: unknown cpu" {
+  stub uname "-a : echo Linux foobar"
+
+  run "$PWD/hooks/pre-checkout"
+
+  [ "$status" -eq 3 ]
+
+  unstub uname
+}
+
+@test "download_trivy: curl failure" {
+  stub uname "-a : echo FreeBSD amd64"
+  stub curl "* : exit 66"
+
+  run "$PWD/hooks/pre-checkout"
+
+  [ "$status" -eq 41 ]
+
+  unstub uname
+  unstub curl
+}
+
+@test "download_trivy: no hashes" {
+  stub uname "-a : echo FreeBSD amd64"
+  stub curl "* : echo ''"
+
+  run "$PWD/hooks/pre-checkout"
+
+  [ "$status" -eq 42 ]
+
+  unstub uname
+  unstub curl
+}
+
+@test "download_trivy: no matching hash" {
+  stub uname "-a : echo FreeBSD amd64"
+  stub curl "* : printf '%s\n%s\n' 'foo foo' 'bar bar'"
+
+  run "$PWD/hooks/pre-checkout"
+
+  [ "$status" -eq 43 ]
+
+  unstub uname
+  unstub curl
+}
+

--- a/tests/pre-checkout.bats
+++ b/tests/pre-checkout.bats
@@ -5,12 +5,20 @@ load '/usr/local/lib/bats/load.bash'
 # Uncomment the following line to debug stub failures
 # export BUILDKITE_AGENT_STUB_DEBUG=/dev/tty
 
+readonly TESTV='6.6.6'
+
 setup() {
+  export BUILDKITE_PLUGIN_TRIVY_VERSION="${TESTV}"
   stub buildkite-agent "* : exit 0"
 }
 
 teardown() {
-  unstub buildkite-agent
+  unset BUILDKITE_PLUGIN_TRIVY_VERSION
+  # Handle scenarios where the stub is never called by returning 0.
+  # This is because unstub throws an error if the stub was never
+  # executed. We need to do so because there are scenarios where
+  # buildkite-agent is never called.
+  unstub buildkite-agent || return 0
 }
 
 @test "trivy_os_cpu_string: uname failure" {
@@ -43,7 +51,7 @@ teardown() {
   unstub uname
 }
 
-@test "download_trivy: curl failure" {
+@test "download_trivy: curl hashes file failure" {
   stub uname "-a : echo FreeBSD amd64"
   stub curl "* : exit 66"
 
@@ -79,3 +87,284 @@ teardown() {
   unstub curl
 }
 
+@test "download_trivy: mktemp failure" {
+  stub uname "-a : echo FreeBSD amd64"
+  stub curl "--fail -L https://github.com/aquasecurity/trivy/releases/download/v${TESTV}/trivy_${TESTV}_checksums.txt : echo '82678d08fe942e81f8bb72a13e70bc3696f9a69756bdb2ee507e0f57cb5b3777  trivy_${TESTV}_FreeBSD-64bit.tar.gz'"
+  stub mktemp "* : exit 123"
+
+  run "$PWD/hooks/pre-checkout"
+
+  [ "$status" -eq 44 ]
+
+  unstub uname
+  unstub curl
+  unstub mktemp
+}
+
+@test "download_trivy: curl trivy exectuable failure" {
+  stub uname "-a : echo FreeBSD amd64"
+  stub mktemp "-d : echo /tmp/x"
+  stub curl \
+    "--fail -L https://github.com/aquasecurity/trivy/releases/download/v${TESTV}/trivy_${TESTV}_checksums.txt : echo 'aec070645fe53ee3b3763059376134f058cc337247c978add178b6ccdfb0019f  trivy_${TESTV}_FreeBSD-64bit.tar.gz'" \
+    "--fail -L -o /tmp/x/temp-trivy.tar.gz https://github.com/aquasecurity/trivy/releases/download/v${TESTV}/trivy_${TESTV}_FreeBSD-64bit.tar.gz : exit 123"
+
+  run "$PWD/hooks/pre-checkout"
+
+  [ "$status" -eq 45 ]
+
+  unstub uname
+  unstub mktemp
+  unstub curl
+}
+
+@test "sha2_256_hash_file: target file missing" {
+  stub uname "-a : echo FreeBSD amd64"
+  stub mktemp "-d : echo /tmp/x"
+  stub curl \
+    "--fail -L https://github.com/aquasecurity/trivy/releases/download/v${TESTV}/trivy_${TESTV}_checksums.txt : echo 'AAAA  trivy_${TESTV}_FreeBSD-64bit.tar.gz'" \
+    "--fail -L -o /tmp/x/temp-trivy.tar.gz https://github.com/aquasecurity/trivy/releases/download/v${TESTV}/trivy_${TESTV}_FreeBSD-64bit.tar.gz : echo foobar"
+
+  run "$PWD/hooks/pre-checkout"
+
+  [ "$status" -eq 31 ]
+
+  unstub uname
+  unstub mktemp
+  unstub curl
+}
+
+@test "sha2_256_hash_file: empty hash result" {
+  temp="$(mktemp -d)"
+  tar_file="${temp}/temp-trivy.tar.gz"
+
+  stub uname "-a : echo FreeBSD amd64"
+  stub mktemp "-d : echo ${temp}"
+  stub curl \
+    "--fail -L https://github.com/aquasecurity/trivy/releases/download/v${TESTV}/trivy_${TESTV}_checksums.txt : echo 'AAAA  trivy_${TESTV}_FreeBSD-64bit.tar.gz'" \
+    "--fail -L -o ${tar_file} https://github.com/aquasecurity/trivy/releases/download/v${TESTV}/trivy_${TESTV}_FreeBSD-64bit.tar.gz : echo foobar > ${tar_file}"
+  stub sha256sum "* : echo"
+
+  run "$PWD/hooks/pre-checkout"
+
+  [ "$status" -eq 34 ]
+
+  unstub uname
+  unstub curl
+  unstub mktemp
+  unstub sha256sum
+}
+
+@test "sha2_256_hash_file: hash verification failure" {
+  temp="$(mktemp -d)"
+  tar_file="${temp}/temp-trivy.tar.gz"
+
+  stub uname "-a : echo FreeBSD amd64"
+  stub mktemp "-d : echo ${temp}"
+  stub curl \
+    "--fail -L https://github.com/aquasecurity/trivy/releases/download/v${TESTV}/trivy_${TESTV}_checksums.txt : echo 'AAAA  trivy_${TESTV}_FreeBSD-64bit.tar.gz'" \
+    "--fail -L -o ${tar_file} https://github.com/aquasecurity/trivy/releases/download/v${TESTV}/trivy_${TESTV}_FreeBSD-64bit.tar.gz : echo foobar > ${tar_file}"
+  stub sha256sum "* : echo nope"
+
+  run "$PWD/hooks/pre-checkout"
+
+  [ "$status" -eq 35 ]
+
+  unstub uname
+  unstub curl
+  unstub mktemp
+  unstub sha256sum
+}
+
+@test "download_trivy: un-tar failure" {
+  temp="$(mktemp -d)"
+  tar_file="${temp}/temp-trivy.tar.gz"
+
+  stub uname "-a : echo FreeBSD amd64"
+  stub mktemp "-d : echo ${temp}"
+  stub curl \
+    "--fail -L https://github.com/aquasecurity/trivy/releases/download/v${TESTV}/trivy_${TESTV}_checksums.txt : echo 'AAAA  trivy_${TESTV}_FreeBSD-64bit.tar.gz'" \
+    "--fail -L -o ${tar_file} https://github.com/aquasecurity/trivy/releases/download/v${TESTV}/trivy_${TESTV}_FreeBSD-64bit.tar.gz : echo foobar > ${tar_file}"
+  stub sha256sum "* : echo AAAA"
+  stub tar "* : exit 123"
+
+  run "$PWD/hooks/pre-checkout"
+
+  [ "$status" -eq 46 ]
+
+  unstub uname
+  unstub curl
+  unstub mktemp
+  unstub sha256sum
+  unstub tar
+}
+
+@test "download_trivy: trivy missing from tar file" {
+  temp="$(mktemp -d)"
+  tar_file="${temp}/temp-trivy.tar.gz"
+
+  stub uname "-a : echo FreeBSD amd64"
+  stub mktemp "-d : echo ${temp}"
+  stub curl \
+    "--fail -L https://github.com/aquasecurity/trivy/releases/download/v${TESTV}/trivy_${TESTV}_checksums.txt : echo 'AAAA  trivy_${TESTV}_FreeBSD-64bit.tar.gz'" \
+    "--fail -L -o ${tar_file} https://github.com/aquasecurity/trivy/releases/download/v${TESTV}/trivy_${TESTV}_FreeBSD-64bit.tar.gz : echo foobar > ${tar_file}"
+  stub sha256sum "* : echo AAAA"
+  stub tar "* : exit 0"
+
+  run "$PWD/hooks/pre-checkout"
+
+  [ "$status" -eq 47 ]
+
+  unstub uname
+  unstub curl
+  unstub mktemp
+  unstub sha256sum
+  unstub tar
+}
+
+@test "main: existing trivy" {
+  temp="$(mktemp -d)"
+  trivy_exe="${temp}/trivy"
+  touch "${trivy_exe}"
+
+  stub which "trivy : echo ${trivy_exe}"
+  echo "${trivy_exe}"
+
+  run "$PWD/hooks/pre-checkout"
+
+  [ "$output" == "${trivy_exe}" ]
+
+  unstub which
+}
+
+@test "main: trivy downloaded from internets to temp" {
+  temp="$(mktemp -d)"
+  tar_file="${temp}/temp-trivy.tar.gz"
+  trivy_exe="${temp}/trivy"
+
+  stub which \
+    "trivy : exit 1" \
+    "sha256sum : exit 0"
+  stub uname "-a : echo FreeBSD amd64"
+  stub mktemp "-d : echo ${temp}"
+  stub curl \
+    "--fail -L https://github.com/aquasecurity/trivy/releases/download/v${TESTV}/trivy_${TESTV}_checksums.txt : echo 'AAAA  trivy_${TESTV}_FreeBSD-64bit.tar.gz'" \
+    "--fail -L -o ${tar_file} https://github.com/aquasecurity/trivy/releases/download/v${TESTV}/trivy_${TESTV}_FreeBSD-64bit.tar.gz : echo foobar > ${tar_file}"
+  stub sha256sum "* : echo AAAA"
+  stub tar "* : touch ${trivy_exe}"
+
+  run "$PWD/hooks/pre-checkout"
+
+  [ "$output" == "${trivy_exe}" ]
+
+  unstub which
+  unstub uname
+  unstub curl
+  unstub mktemp
+  unstub sha256sum
+  unstub tar
+}
+
+@test "main: trivy downloaded from internets and installed - mkdir failure" {
+  temp="$(mktemp -d)"
+  tar_file="${temp}/temp-trivy.tar.gz"
+  trivy_exe="${temp}/trivy"
+  export BUILDKITE_PLUGIN_TRIVY_INSTALL_IN_HOME_BIN=true
+  home_bin="${HOME}/bin"
+
+  stub which \
+    "trivy : exit 1" \
+    "sha256sum : exit 0"
+  stub uname "-a : echo FreeBSD amd64"
+  stub mktemp "-d : echo ${temp}"
+  stub curl \
+    "--fail -L https://github.com/aquasecurity/trivy/releases/download/v${TESTV}/trivy_${TESTV}_checksums.txt : echo 'AAAA  trivy_${TESTV}_FreeBSD-64bit.tar.gz'" \
+    "--fail -L -o ${tar_file} https://github.com/aquasecurity/trivy/releases/download/v${TESTV}/trivy_${TESTV}_FreeBSD-64bit.tar.gz : echo foobar > ${tar_file}"
+  stub sha256sum "* : echo AAAA"
+  stub tar "* : touch ${trivy_exe}"
+  stub mkdir "-m 0700 ${home_bin} : exit 123"
+
+  run "$PWD/hooks/pre-checkout"
+
+  [ "$status" -eq 50 ]
+
+  unstub which
+  unstub uname
+  unstub curl
+  unstub mktemp
+  unstub sha256sum
+  unstub tar
+  unstub mkdir
+  unset BUILDKITE_PLUGIN_TRIVY_INSTALL_IN_HOME_BIN
+}
+
+@test "main: trivy downloaded from internets and installed - mv failure" {
+  temp="$(mktemp -d)"
+  tar_file="${temp}/temp-trivy.tar.gz"
+  trivy_exe="${temp}/trivy"
+  export BUILDKITE_PLUGIN_TRIVY_INSTALL_IN_HOME_BIN=true
+  home_bin="${HOME}/bin"
+  home_bin_trivy="${home_bin}/trivy"
+
+  stub which \
+    "trivy : exit 1" \
+    "sha256sum : exit 0"
+  stub uname "-a : echo FreeBSD amd64"
+  stub mktemp "-d : echo ${temp}"
+  stub curl \
+    "--fail -L https://github.com/aquasecurity/trivy/releases/download/v${TESTV}/trivy_${TESTV}_checksums.txt : echo 'AAAA  trivy_${TESTV}_FreeBSD-64bit.tar.gz'" \
+    "--fail -L -o ${tar_file} https://github.com/aquasecurity/trivy/releases/download/v${TESTV}/trivy_${TESTV}_FreeBSD-64bit.tar.gz : echo foobar > ${tar_file}"
+  stub sha256sum "* : echo AAAA"
+  stub tar "* : touch ${trivy_exe}"
+  stub mkdir "-m 0700 ${home_bin} : exit 0"
+  stub mv "${trivy_exe} ${home_bin_trivy} : exit 123"
+
+  run "$PWD/hooks/pre-checkout"
+
+  [ "$status" -eq 51 ]
+
+  unstub which
+  unstub uname
+  unstub curl
+  unstub mktemp
+  unstub sha256sum
+  unstub tar
+  unstub mkdir
+  unstub mv
+  unset BUILDKITE_PLUGIN_TRIVY_INSTALL_IN_HOME_BIN
+}
+
+@test "main: trivy downloaded from internets and then installed" {
+  temp="$(mktemp -d)"
+  tar_file="${temp}/temp-trivy.tar.gz"
+  trivy_exe="${temp}/trivy"
+  export BUILDKITE_PLUGIN_TRIVY_INSTALL_IN_HOME_BIN=true
+  home_bin="${HOME}/bin"
+  home_bin_trivy="${home_bin}/trivy"
+
+  stub which \
+    "trivy : exit 1" \
+    "sha256sum : exit 0"
+  stub uname "-a : echo FreeBSD amd64"
+  stub mktemp "-d : echo ${temp}"
+  stub curl \
+    "--fail -L https://github.com/aquasecurity/trivy/releases/download/v${TESTV}/trivy_${TESTV}_checksums.txt : echo 'AAAA  trivy_${TESTV}_FreeBSD-64bit.tar.gz'" \
+    "--fail -L -o ${tar_file} https://github.com/aquasecurity/trivy/releases/download/v${TESTV}/trivy_${TESTV}_FreeBSD-64bit.tar.gz : echo foobar > ${tar_file}"
+  stub sha256sum "* : echo AAAA"
+  stub tar "* : touch ${trivy_exe}"
+  stub mkdir "-m 0700 ${home_bin} : exit 0"
+  stub mv "${trivy_exe} ${home_bin_trivy} : exit 0"
+
+  run "$PWD/hooks/pre-checkout"
+
+  [ "$output" == "${home_bin_trivy}" ]
+
+  unstub which
+  unstub uname
+  unstub curl
+  unstub mktemp
+  unstub sha256sum
+  unstub tar
+  unstub mkdir
+  unstub mv
+  unset BUILDKITE_PLUGIN_TRIVY_INSTALL_IN_HOME_BIN
+}


### PR DESCRIPTION
This is my initial take on installing trivy from a GitHub release. The script will first check if trivy can be found in any of the directories listed in the PATH environment variable. If trivy cannot be located in any of the PATH directories, the script will do the following:

1. Determine the current OS and CPU
2. Download trivy's hashes and tar.gz from GitHub
3. Authenticate the trivy tar.gz using the hashes file
4. Do either of the following:
4a. Move the trivy executable to ${HOME}/bin if the "install-in-home-bin" option is set to "true" or "yes"
4b. Leave the executable in a temporary directory
5. Write the executable's file path to stdout and set an environment variable containing the executable's file path

The final move / rename logic is configurable. The user can specify the "install-in-home-bin" parameter with a value of "yes" or "true" (in upper or lowercase). In such a case, the script moves the executable to ${HOME}/bin. If the parameter is not specified, then the trivy executable remains in a temporary directory.

The trivy executable's final file path is written to stdout. The script sets an environment variable that points at the final executable's file path. Refer to the script's initial comments for more information.