### PR TITLE
Track trivy version with Renovate

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,3 +39,13 @@ jobs:
       uses: ludeeus/action-shellcheck@master
       env:
         SHELLCHECK_OPTS: -x
+
+  renovate-config:
+    name: Validate Renovate config
+    runs-on: ubuntu-latest
+    env:
+      RENOVATE_CONFIG_FILE: renovate.json
+    steps:
+      - uses: actions/checkout@v3
+      - name: testing Renovate config
+        run: npx -p renovate renovate-config-validator

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 # NOTE(jaosorior): This is duplicated in the tests.
-export default_version="0.29.2"
-export version="${BUILDKITE_PLUGIN_TRIVY_VERSION:-$default_version}"
-export image="aquasec/trivy:${version}"
+readonly TRIVY_DEFAULT_VERSION="0.29.2"
+export TRIVY_VERSION="${BUILDKITE_PLUGIN_TRIVY_VERSION:-$TRIVY_DEFAULT_VERSION}"
+export image="aquasec/trivy:${TRIVY_VERSION}"
 
 args=()
 fsargs=()

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,14 @@
 {
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "extends": [
       "config:base"
+    ],
+    "regexManagers": [
+      {
+        "fileMatch": ["^(hooks/*|tests/*.bats)$"],
+        "matchStrings": ["readonly TRIVY_DEFAULT_VERSION=(?<currentValue>.*?)\\s"],
+        "depNameTemplate": "aquasec/trivy",
+        "datasourceTemplate": "docker"
+      }
     ]
   }

--- a/tests/post-command.bats
+++ b/tests/post-command.bats
@@ -3,9 +3,9 @@
 load '/usr/local/lib/bats/load.bash'
 
 # NOTE(jaosorior): This is duplicated in the hook.
-export default_version="0.29.2"
-export version="${BUILDKITE_PLUGIN_TRIVY_VERSION:-$default_version}"
-export image="aquasec/trivy:${version}"
+readonly TRIVY_DEFAULT_VERSION="0.29.2"
+export TRIVY_VERSION="${BUILDKITE_PLUGIN_TRIVY_VERSION:-$TRIVY_DEFAULT_VERSION}"
+export image="aquasec/trivy:${TRIVY_VERSION}"
 
 # Uncomment the following line to debug stub failures
 # export BUILDKITE_AGENT_STUB_DEBUG=/dev/tty


### PR DESCRIPTION
This uses the regexManager [1] to track Trivy version updates using
Renovate. This currently hardcodes the dependency sources to be Docker,
however, when we switch to direct releases from trivy [2] we'll need to
change the tracking system to use `github-tags` instead.

[1] https://docs.renovatebot.com/modules/manager/regex/
[2] https://github.com/equinixmetal-buildkite/trivy-buildkite-plugin/pull/15

Closes #18 

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
