### PR TITLE
Fix renovate regex config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,8 +5,8 @@
     ],
     "regexManagers": [
       {
-        "fileMatch": ["^(hooks/*|tests/*.bats)$"],
-        "matchStrings": ["readonly TRIVY_DEFAULT_VERSION=(?<currentValue>.*?)\\s"],
+        "fileMatch": ["^(hooks\/.+|tests\/+.bats)$"],
+        "matchStrings": ["readonly TRIVY_DEFAULT_VERSION=\"(?<currentValue>.*?)\"\\s"],
         "depNameTemplate": "aquasec/trivy",
         "datasourceTemplate": "docker"
       }


### PR DESCRIPTION
This actually helps the regex work as it should have.

To test this, I forked the repository and pointed renovate towards the
forked configuration. This way, I was able to do a dry run with
renovate's container.

The command I ran was as follows:

```bash
docker run --rm -it -v $PWD/config.js:/usr/src/app/config.js -v /tmp:/tmp -e LOG_LEVEL=debug renovate/renovate:latest JAORMX/trivy-buildkite-plugin --include-forks true --dry-run --use-base-branch-config fix-renovate
```

The following output demonstrated that the regex was detected and may
issue an udpate:

```
...
         "regex": [
           {
             "packageFile": "hooks/post-command",
             "deps": [
               {
                 "depName": "aquasec/trivy",
                 "currentValue": "0.29.2",
                 "datasource": "docker",
                 "replaceString": "readonly TRIVY_DEFAULT_VERSION=\"0.29.2\"\n",
                 "depIndex": 0,
                 "updates": [
                   {
                     "bucket": "non-major",
                     "newVersion": "0.31.3",
                     "newValue": "0.31.3",
                     "newMajor": 0,
                     "newMinor": 31,
                     "updateType": "minor",
                     "branchName": "renovate/aquasec-trivy-0.x"
                   }
                 ],
                 "warnings": [],
                 "versioning": "docker",
                 "sourceUrl": "https://github.com/aquasecurity/trivy",
                 "currentVersion": "0.29.2",
                 "isSingleVersion": true,
                 "fixedVersion": "0.29.2"
               }
             ],
             "matchStrings": [
               "readonly TRIVY_DEFAULT_VERSION=\"(?<currentValue>.*?)\"\\s"
             ],
             "depNameTemplate": "aquasec/trivy",
             "datasourceTemplate": "docker"
           }
         ]
...
```

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
