### PR TITLE
Update README and add Makefile for tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,30 +6,24 @@ on:
   pull_request:
 
 jobs:
-  plugin-tests:
-    name: Tests
+  test:
     runs-on: ubuntu-latest
-    container:
-      image: buildkite/plugin-tester:latest
-      volumes:
-        - "${{github.workspace}}:/plugin"
     steps:
-      - uses: actions/checkout@v3
-      - name: tests
-        run: bats tests/
-        working-directory: /plugin
+    - uses: actions/checkout@v3
+    - run:
+        make test
 
-  plugin-lint:
-    name: Lint
+  lint:
     runs-on: ubuntu-latest
-    container:
-      image: buildkite/plugin-linter:latest
-      volumes:
-        - "${{github.workspace}}:/plugin"
     steps:
-      - uses: actions/checkout@v3
-      - name: lint
-        run: lint --id trivy
+    - uses: actions/checkout@v3
+      with:
+        # This fetches all branches and tags, which helps us lint that we're using the current version
+        # in our examples.
+        fetch-depth: 0
+    - run:
+        make lint
+
   shellcheck:
     name: Shellcheck
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+.PHONY: lint
+lint: | plugin-arg-docs
+	docker run --rm -v "$$PWD:/plugin:ro" buildkite/plugin-linter --id equinixmetal-buildkite/trivy
+
+.PHONY: test
+test:
+	docker run --rm -v "$$PWD:/plugin:ro" buildkite/plugin-tester
+
+.PHONY: plugin-arg-docs
+plugin-arg-docs: ## Ensures that the plugin arguments are documented
+	@echo "Checking that all properties are documented in the README"
+	@yq '.configuration.properties | keys' plugin.yml | awk '{print $$2}' | xargs -n1 -I % grep -qE "### \`%\`" README.md || \
+		{ echo "All properties must be documented in the README"; exit 1; }

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Add the following to your `pipeline.yml`:
 steps:
   - command: ls
     plugins:
-      - trivy#v1.13.0: ~
+      - equinixmetal-buildkite/trivy#v1.14.2: ~
 ```
 Define `--exit-code` option as a plugin parameter in  `pipeline.yml` to fail the pipeline when there are vulnerabilities:
 
@@ -27,7 +27,7 @@ Define `--exit-code` option as a plugin parameter in  `pipeline.yml` to fail the
 steps:
   - command: ls
     plugins:
-      - trivy#v1.13.0:
+      - equinixmetal-buildkite/trivy#v1.14.2:
         exit-code: 1
 ```
 
@@ -38,9 +38,37 @@ Below is an example for scanning `CRITICAL` vulnerabilities.
 steps:
   - command: ls
     plugins:
-      - trivy#v1.13.0:
+      - equinixmetal-buildkite/trivy#v1.14.2:
         severity: "CRITICAL"
 ```
+
+## Configuration
+
+### `exit-code` (Optional, array)
+
+Controls whether the security scan is blocking or not. This is done by setting the exit code of the plugin. If the exit code is set to 0, the pipeline will continue. If the exit code is set to 1, the pipeline will fail. (Defaults to 0)
+
+### `severity` (Optional, string)
+
+Controls the severity of the vulnerabilities to be scanned. (Defaults to "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL")
+
+### `ignore-unfixed` (Optional, boolean)
+
+Controls whether to display only fixed vulnerabilities. (Defaults to false)
+
+### `security-checks` (Optional, string)
+
+Controls the security checks to be performed. (Defaults to "vuln,config")
+
+### `image-ref` (Optional, string)
+
+Controls the image reference to be scanned. If no image is specified the image scanning step is skipped. This is also able to infer the image from the [`docker-metadata` plugin](https://github.com/equinixmetal-buildkite/docker-metadata-buidkite-plugin), but one needs to ensure that the images are built
+before calling the `trivy` plugin. (Defaults to "")
+
+### `trivy-version` (Optional, string)
+
+Controls the version of trivy to be used.
+
 ## Developing
 
 Provide examples on how to modify and test, e.g.:
@@ -48,5 +76,5 @@ Provide examples on how to modify and test, e.g.:
 To run the tests:
 
 ```shell
-docker-compose run --rm tests
+make test
 ```


### PR DESCRIPTION
The Makefile ensures we're able to run tests in a consistent manner in
the same way CI will run them. Thus helping us in developing in a more
predictable manner. This is the same Makefile as other plugins are using
(`docker-build` and `docker-metadata`).

With the new linting, we also needed to fix the README file to ensure
that we now adhere to the linting standards. e.g. all plugin options
need to be documented, and the examples need to match the current
version.

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
