### PR TITLE
Add separators for easier browsing

### DIFF
--- a/hooks/post-command
+++ b/hooks/post-command
@@ -93,7 +93,7 @@ else
   fsargs+=("--security-checks" "vuln,config")
 fi
 
-echo "scanning filesystem"
+echo "--- scanning filesystem"
 trivy fs "${args[@]}" "${fsargs[@]}" .
 status=$?
 
@@ -141,7 +141,7 @@ else
   echo "image '$targetimageref' already present locally"
 fi
 
-echo "scanning container image"
+echo "--- scanning container image"
 trivy image "${args[@]}" "$targetimageref"
 status=$?
 


### PR DESCRIPTION
This adds the `---` character which adds a separator in the buildkite
output. It makes it easier to browse when debugging the output.

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
