### PR TITLE
Track image references in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,16 @@
+BUILDKITE_TESTER_IMAGE=buildkite/plugin-tester:v2.0.0
+
+# NOTE(jaosorior): This hasn't been released in two years...
+#                  we should ask for a fix.
+BUILDKITE_LINTER_IMAGE=buildkite/plugin-linter:latest
+
 .PHONY: lint
 lint: | plugin-arg-docs
-	docker run --rm -v "$$PWD:/plugin:ro" buildkite/plugin-linter --id equinixmetal-buildkite/trivy
+	docker run --rm -v "$$PWD:/plugin:ro" $(BUILDKITE_LINTER_IMAGE) --id equinixmetal-buildkite/trivy
 
 .PHONY: test
 test:
-	docker run --rm -v "$$PWD:/plugin:ro" buildkite/plugin-tester:v2.0.0
+	docker run --rm -v "$$PWD:/plugin:ro" $(BUILDKITE_TESTER_IMAGE)
 
 .PHONY: plugin-arg-docs
 plugin-arg-docs: ## Ensures that the plugin arguments are documented

--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,15 @@
         "matchStrings": ["readonly TRIVY_DEFAULT_VERSION=\"(?<currentValue>.*?)\"\\s"],
         "depNameTemplate": "aquasec/trivy",
         "datasourceTemplate": "docker"
+      },
+      {
+        "fileMatch": [
+          "^Makefile$"
+        ],
+        "matchStrings": [
+            "[A-Z_]+_IMAGE=(?<depName>.*?):(?<currentValue>.*?)\\n"
+        ],
+        "datasourceTemplate": "docker"
       }
     ]
   }


### PR DESCRIPTION
This sets up a regexManager entry in Renovate to allow us to get
automatic updates to contianer images declared in the Makefile.

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
