### PR TITLE
Persist fs scan error even if container image wasn't given

### DIFF
--- a/hooks/post-command
+++ b/hooks/post-command
@@ -129,7 +129,7 @@ fi
 if [[ -z "$targetimageref" ]]; then
   echo "no image to scan"
   display_success "No container image was scanned due to a lack of an image reference. This is fine."
-  exit 0
+  exit $final_status
 fi
 
 # If the image is not present locally, pull it

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -95,13 +95,11 @@ fi
 
 echo "--- scanning filesystem"
 trivy fs "${args[@]}" "${fsargs[@]}" .
-status=$?
-
 # Status gets overwritten by the next scan, so we save it here
 # This way, we actually exit with a failure.
-final_status=$status
+final_status=$?
 
-if [[ $status -ne 0 ]]; then
+if [[ $final_status -ne 0 ]]; then
   display_error "trivy found vulnerabilities in repository. See the job output for details."
 else
   display_success "trivy didn't find any relevant vulnerabilities in the repository"

--- a/tests/post-command.bats
+++ b/tests/post-command.bats
@@ -69,7 +69,7 @@ export TRIVY_EXE_PATH="$(mktemp)"
 
   run "$PWD/hooks/post-command"
 
-  assert_success
+  assert_failure
   assert_output --partial "scanning filesystem"
   assert_output --partial "fs scan failure"
   assert_output --partial "using exit-code=1 option while scanning"


### PR DESCRIPTION
Instead of passing the scan if a container image wasn't given, this persists in the filesystem status. This is now only given as `final_status` to denote that it'll be final even if no image was given, thus also not doing double assignments anymore.

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
