### PR TITLE
Output multiple annotations instead of appending

### DIFF
--- a/hooks/post-command
+++ b/hooks/post-command
@@ -4,20 +4,22 @@
 ##################
 
 fail_with_message() {
-  display_error "$1"
+  display_error "$1" "$2"
   exit 1
 }
 
 display_error() {
-  message="$1"
+  ctx="$1"
+  message="$2"
   echo "🚨 $message" >&2
-  buildkite-agent annotate --style error "$message<br />" --context publish --append
+  buildkite-agent annotate --style error "$message<br />" --context "$ctx"
 }
 
 display_success() {
-  message="$1"
+  ctx="$1"
+  message="$2"
   echo "$message"
-  buildkite-agent annotate --style success "$message<br />" --context publish --append
+  buildkite-agent annotate --style success "$message<br />" --context "$ctx"
 }
 
 docker_metadata_list_into_result() {
@@ -26,7 +28,7 @@ docker_metadata_list_into_result() {
     filepath="$DOCKER_METADATA_DIR/$field"
 
     if [[ ! -f "$filepath" ]] ; then
-      fail_with_message "No '$field' directory found in $DOCKER_METADATA_DIR"
+      fail_with_message "trivy-container-scan" "No '$field' directory found in $DOCKER_METADATA_DIR"
     fi
 
     result=()
@@ -52,10 +54,10 @@ docker_metadata_file_exists() {
 ######
 
 [[ -z "${TRIVY_EXE_PATH}" ]] \
-  && fail_with_message "TRIVY_EXE_PATH env. is unset or empty"
+  && fail_with_message "trivy-scan" "TRIVY_EXE_PATH env. is unset or empty"
 
 [[ ! -f "${TRIVY_EXE_PATH}" ]] \
-  && fail_with_message "trivy exe file does not exist ('${TRIVY_EXE_PATH}')"
+  && fail_with_message "trivy-scan" "trivy exe file does not exist ('${TRIVY_EXE_PATH}')"
 
 # I would prefer to just execute the path pointed-to by this environment
 # variable - but that is incompatible with the testing framework. As a
@@ -100,9 +102,9 @@ trivy fs "${args[@]}" "${fsargs[@]}" .
 final_status=$?
 
 if [[ $final_status -ne 0 ]]; then
-  display_error "trivy found vulnerabilities in repository. See the job output for details."
+  display_error "trivy-fs-scan" "trivy found vulnerabilities in repository. See the job output for details."
 else
-  display_success "trivy didn't find any relevant vulnerabilities in the repository"
+  display_success "trivy-fs-scan" "trivy didn't find any relevant vulnerabilities in the repository"
 fi
 
 
@@ -128,7 +130,7 @@ fi
 # This might be intended, so let's just pass.
 if [[ -z "$targetimageref" ]]; then
   echo "no image to scan"
-  display_success "No container image was scanned due to a lack of an image reference. This is fine."
+  display_success "trivy-container-scan" "No container image was scanned due to a lack of an image reference. This is fine."
   exit $final_status
 fi
 
@@ -144,9 +146,9 @@ trivy image "${args[@]}" "$targetimageref"
 status=$?
 
 if [[ $status -ne 0 ]]; then
-  fail_with_message "trivy found vulnerabilities in the container image. See the job output for details."
+  fail_with_message "trivy-container-scan" "trivy found vulnerabilities in the container image. See the job output for details."
 else
-  display_success "trivy didn't find any relevant vulnerabilities in the container image"
+  display_success "trivy-container-scan" "trivy didn't find any relevant vulnerabilities in the container image"
 fi
 
 exit $final_status

--- a/hooks/pre-checkout
+++ b/hooks/pre-checkout
@@ -42,13 +42,7 @@ die() {
 display_error() {
   message="$1"
   echo "🚨 $message" >&2
-  buildkite-agent annotate --style error "$message<br />" --context publish --append
-}
-
-display_success() {
-  message="$1"
-  echo "$message"
-  buildkite-agent annotate --style success "$message<br />" --context publish --append
+  buildkite-agent annotate --style error "$message<br />" --context trivy-scan
 }
 
 # trivy_os_cpu_string retrieves information from the runtime

--- a/tests/post-command.bats
+++ b/tests/post-command.bats
@@ -10,8 +10,8 @@ export TRIVY_EXE_PATH="$(mktemp)"
 @test "fs scan of a test app" {
   # TODO(jaosorior): Change the exit code if we change the default
   stub trivy "fs --exit-code 0 --security-checks vuln,config . : echo fs scan success"
-  stub buildkite-agent "annotate --style success \"trivy didn't find any relevant vulnerabilities in the repository<br />\" --context publish --append : echo fs scan success" \
-    "annotate --style success \"No container image was scanned due to a lack of an image reference. This is fine.<br />\" --context publish --append : echo no image scan happened" \
+  stub buildkite-agent "annotate --style success \"trivy didn't find any relevant vulnerabilities in the repository<br />\" --context trivy-fs-scan : echo fs scan success" \
+    "annotate --style success \"No container image was scanned due to a lack of an image reference. This is fine.<br />\" --context trivy-container-scan : echo no image scan happened" \
 
   run "$PWD/hooks/post-command"
 
@@ -28,8 +28,8 @@ export TRIVY_EXE_PATH="$(mktemp)"
   export BUILDKITE_PLUGIN_TRIVY_EXIT_CODE=1
 
   stub trivy "fs --exit-code 1 --security-checks vuln,config . : echo fs scan success"
-  stub buildkite-agent "annotate --style success \"trivy didn't find any relevant vulnerabilities in the repository<br />\" --context publish --append : echo fs scan success" \
-    "annotate --style success \"No container image was scanned due to a lack of an image reference. This is fine.<br />\" --context publish --append : echo no image scan happened" \
+  stub buildkite-agent "annotate --style success \"trivy didn't find any relevant vulnerabilities in the repository<br />\" --context trivy-fs-scan : echo fs scan success" \
+    "annotate --style success \"No container image was scanned due to a lack of an image reference. This is fine.<br />\" --context trivy-container-scan : echo no image scan happened" \
 
   run "$PWD/hooks/post-command"
 
@@ -46,8 +46,8 @@ export TRIVY_EXE_PATH="$(mktemp)"
   export BUILDKITE_PLUGIN_TRIVY_EXIT_CODE=0
 
   stub trivy "fs --exit-code 0 --security-checks vuln,config . : echo fs scan success"
-  stub buildkite-agent "annotate --style success \"trivy didn't find any relevant vulnerabilities in the repository<br />\" --context publish --append : echo fs scan success" \
-    "annotate --style success \"No container image was scanned due to a lack of an image reference. This is fine.<br />\" --context publish --append : echo no image scan happened" \
+  stub buildkite-agent "annotate --style success \"trivy didn't find any relevant vulnerabilities in the repository<br />\" --context trivy-fs-scan : echo fs scan success" \
+    "annotate --style success \"No container image was scanned due to a lack of an image reference. This is fine.<br />\" --context trivy-container-scan : echo no image scan happened" \
 
   run "$PWD/hooks/post-command"
 
@@ -64,8 +64,8 @@ export TRIVY_EXE_PATH="$(mktemp)"
   export BUILDKITE_PLUGIN_TRIVY_EXIT_CODE=1
 
   stub trivy "fs --exit-code 1 --security-checks vuln,config . : exit 1"
-  stub buildkite-agent "annotate --style error \"trivy found vulnerabilities in repository. See the job output for details.<br />\" --context publish --append : echo fs scan failure" \
-    "annotate --style success \"No container image was scanned due to a lack of an image reference. This is fine.<br />\" --context publish --append : echo no image scan happened" \
+  stub buildkite-agent "annotate --style error \"trivy found vulnerabilities in repository. See the job output for details.<br />\" --context trivy-fs-scan : echo fs scan failure" \
+    "annotate --style success \"No container image was scanned due to a lack of an image reference. This is fine.<br />\" --context trivy-container-scan : echo no image scan happened" \
 
   run "$PWD/hooks/post-command"
 
@@ -83,8 +83,8 @@ export TRIVY_EXE_PATH="$(mktemp)"
   export BUILDKITE_PLUGIN_TRIVY_EXIT_CODE=1
 
   stub trivy "fs --exit-code 1 --severity $BUILDKITE_PLUGIN_TRIVY_SEVERITY --security-checks vuln,config . : echo fs scan success"
-  stub buildkite-agent "annotate --style success \"trivy didn't find any relevant vulnerabilities in the repository<br />\" --context publish --append : echo fs scan success" \
-    "annotate --style success \"No container image was scanned due to a lack of an image reference. This is fine.<br />\" --context publish --append : echo no image scan happened" \
+  stub buildkite-agent "annotate --style success \"trivy didn't find any relevant vulnerabilities in the repository<br />\" --context trivy-fs-scan : echo fs scan success" \
+    "annotate --style success \"No container image was scanned due to a lack of an image reference. This is fine.<br />\" --context trivy-container-scan : echo no image scan happened" \
 
   run "$PWD/hooks/post-command"
 
@@ -101,8 +101,8 @@ export TRIVY_EXE_PATH="$(mktemp)"
   export BUILDKITE_PLUGIN_TRIVY_EXIT_CODE=1
 
   stub trivy "fs --exit-code 1 --severity $BUILDKITE_PLUGIN_TRIVY_SEVERITY --security-checks vuln,config . : echo fs scan success"
-  stub buildkite-agent "annotate --style success \"trivy didn't find any relevant vulnerabilities in the repository<br />\" --context publish --append : echo fs scan success" \
-    "annotate --style success \"No container image was scanned due to a lack of an image reference. This is fine.<br />\" --context publish --append : echo no image scan happened" \
+  stub buildkite-agent "annotate --style success \"trivy didn't find any relevant vulnerabilities in the repository<br />\" --context trivy-fs-scan : echo fs scan success" \
+    "annotate --style success \"No container image was scanned due to a lack of an image reference. This is fine.<br />\" --context trivy-container-scan : echo no image scan happened" \
 
   run "$PWD/hooks/post-command"
 
@@ -119,8 +119,8 @@ export TRIVY_EXE_PATH="$(mktemp)"
   export BUILDKITE_PLUGIN_TRIVY_EXIT_CODE=1
 
   stub trivy "fs --exit-code 1 --severity $BUILDKITE_PLUGIN_TRIVY_SEVERITY --security-checks vuln,config . : echo fs scan success"
-  stub buildkite-agent "annotate --style success \"trivy didn't find any relevant vulnerabilities in the repository<br />\" --context publish --append : echo fs scan success" \
-    "annotate --style success \"No container image was scanned due to a lack of an image reference. This is fine.<br />\" --context publish --append : echo no image scan happened" \
+  stub buildkite-agent "annotate --style success \"trivy didn't find any relevant vulnerabilities in the repository<br />\" --context trivy-fs-scan : echo fs scan success" \
+    "annotate --style success \"No container image was scanned due to a lack of an image reference. This is fine.<br />\" --context trivy-container-scan : echo no image scan happened" \
 
   run "$PWD/hooks/post-command"
 
@@ -135,8 +135,8 @@ export TRIVY_EXE_PATH="$(mktemp)"
 @test "fs scan of a test app with only vulnerbility security check" {
   export BUILDKITE_PLUGIN_TRIVY_SECURITY_CHECKS="vuln"
   stub trivy "fs --exit-code 0 --security-checks $BUILDKITE_PLUGIN_TRIVY_SECURITY_CHECKS . : echo fs scan success"
-  stub buildkite-agent "annotate --style success \"trivy didn't find any relevant vulnerabilities in the repository<br />\" --context publish --append : echo fs scan success" \
-    "annotate --style success \"No container image was scanned due to a lack of an image reference. This is fine.<br />\" --context publish --append : echo no image scan happened" \
+  stub buildkite-agent "annotate --style success \"trivy didn't find any relevant vulnerabilities in the repository<br />\" --context trivy-fs-scan : echo fs scan success" \
+    "annotate --style success \"No container image was scanned due to a lack of an image reference. This is fine.<br />\" --context trivy-container-scan : echo no image scan happened" \
 
   run "$PWD/hooks/post-command"
 
@@ -151,8 +151,8 @@ export TRIVY_EXE_PATH="$(mktemp)"
 @test "fs scan of a test app with vulnerbility and configuration security check" {
   export BUILDKITE_PLUGIN_TRIVY_SECURITY_CHECKS="vuln,config"
   stub trivy "fs --exit-code 0 --security-checks $BUILDKITE_PLUGIN_TRIVY_SECURITY_CHECKS . : echo fs scan success"
-  stub buildkite-agent "annotate --style success \"trivy didn't find any relevant vulnerabilities in the repository<br />\" --context publish --append : echo fs scan success" \
-    "annotate --style success \"No container image was scanned due to a lack of an image reference. This is fine.<br />\" --context publish --append : echo no image scan happened" \
+  stub buildkite-agent "annotate --style success \"trivy didn't find any relevant vulnerabilities in the repository<br />\" --context trivy-fs-scan : echo fs scan success" \
+    "annotate --style success \"No container image was scanned due to a lack of an image reference. This is fine.<br />\" --context trivy-container-scan : echo no image scan happened" \
 
   run "$PWD/hooks/post-command"
 
@@ -167,8 +167,8 @@ export TRIVY_EXE_PATH="$(mktemp)"
 @test "fs scan of a test app with vulnerbility,secret and configuration security check" {
   export BUILDKITE_PLUGIN_TRIVY_SECURITY_CHECKS="vuln,secret,config"
   stub trivy "fs --exit-code 0 --security-checks $BUILDKITE_PLUGIN_TRIVY_SECURITY_CHECKS . : echo fs scan success"
-  stub buildkite-agent "annotate --style success \"trivy didn't find any relevant vulnerabilities in the repository<br />\" --context publish --append : echo fs scan success" \
-    "annotate --style success \"No container image was scanned due to a lack of an image reference. This is fine.<br />\" --context publish --append : echo no image scan happened" \
+  stub buildkite-agent "annotate --style success \"trivy didn't find any relevant vulnerabilities in the repository<br />\" --context trivy-fs-scan : echo fs scan success" \
+    "annotate --style success \"No container image was scanned due to a lack of an image reference. This is fine.<br />\" --context trivy-container-scan : echo no image scan happened" \
 
   run "$PWD/hooks/post-command"
 
@@ -189,8 +189,8 @@ export TRIVY_EXE_PATH="$(mktemp)"
   stub docker \
     "images -q $BUILDKITE_PLUGIN_TRIVY_IMAGE_REF : echo ''" \
     "pull $BUILDKITE_PLUGIN_TRIVY_IMAGE_REF : echo 'pulled image'"
-  stub buildkite-agent "annotate --style success \"trivy didn't find any relevant vulnerabilities in the repository<br />\" --context publish --append : echo fs scan success" \
-    "annotate --style success \"trivy didn't find any relevant vulnerabilities in the container image<br />\" --context publish --append : echo container image scan success" \
+  stub buildkite-agent "annotate --style success \"trivy didn't find any relevant vulnerabilities in the repository<br />\" --context trivy-fs-scan : echo fs scan success" \
+    "annotate --style success \"trivy didn't find any relevant vulnerabilities in the container image<br />\" --context trivy-container-scan : echo container image scan success" \
 
   run "$PWD/hooks/post-command"
 
@@ -212,8 +212,8 @@ export TRIVY_EXE_PATH="$(mktemp)"
     "image --exit-code 0 $BUILDKITE_PLUGIN_TRIVY_IMAGE_REF : echo container image scan success"
   stub docker \
     "images -q $BUILDKITE_PLUGIN_TRIVY_IMAGE_REF : echo 'Found image!'"
-  stub buildkite-agent "annotate --style success \"trivy didn't find any relevant vulnerabilities in the repository<br />\" --context publish --append : echo fs scan success" \
-    "annotate --style success \"trivy didn't find any relevant vulnerabilities in the container image<br />\" --context publish --append : echo container image scan success" \
+  stub buildkite-agent "annotate --style success \"trivy didn't find any relevant vulnerabilities in the repository<br />\" --context trivy-fs-scan : echo fs scan success" \
+    "annotate --style success \"trivy didn't find any relevant vulnerabilities in the container image<br />\" --context trivy-container-scan : echo container image scan success" \
 
   run "$PWD/hooks/post-command"
 
@@ -236,8 +236,8 @@ export TRIVY_EXE_PATH="$(mktemp)"
   stub docker \
     "images -q $BUILDKITE_PLUGIN_TRIVY_IMAGE_REF : echo ''" \
     "pull $BUILDKITE_PLUGIN_TRIVY_IMAGE_REF : echo 'pulled image'"
-  stub buildkite-agent "annotate --style success \"trivy didn't find any relevant vulnerabilities in the repository<br />\" --context publish --append : echo fs scan success" \
-    "annotate --style error \"trivy found vulnerabilities in the container image. See the job output for details.<br />\" --context publish --append : echo container image scan failure" \
+  stub buildkite-agent "annotate --style success \"trivy didn't find any relevant vulnerabilities in the repository<br />\" --context trivy-fs-scan : echo fs scan success" \
+    "annotate --style error \"trivy found vulnerabilities in the container image. See the job output for details.<br />\" --context trivy-container-scan : echo container image scan failure" \
 
   run "$PWD/hooks/post-command"
 
@@ -263,8 +263,8 @@ export TRIVY_EXE_PATH="$(mktemp)"
     "image --exit-code 0 $_TAGS_0 : echo container image scan success"
   stub docker \
     "images -q $_TAGS_0 : echo 'Found image!'"
-  stub buildkite-agent "annotate --style success \"trivy didn't find any relevant vulnerabilities in the repository<br />\" --context publish --append : echo fs scan success" \
-    "annotate --style success \"trivy didn't find any relevant vulnerabilities in the container image<br />\" --context publish --append : echo container image scan success" \
+  stub buildkite-agent "annotate --style success \"trivy didn't find any relevant vulnerabilities in the repository<br />\" --context trivy-fs-scan : echo fs scan success" \
+    "annotate --style success \"trivy didn't find any relevant vulnerabilities in the container image<br />\" --context trivy-container-scan : echo container image scan success" \
 
   run "$PWD/hooks/post-command"
 
@@ -290,8 +290,8 @@ export TRIVY_EXE_PATH="$(mktemp)"
   stub docker \
     "images -q $_TAGS_0 : echo ''" \
     "pull $_TAGS_0 : echo 'pulled image'"
-  stub buildkite-agent "annotate --style success \"trivy didn't find any relevant vulnerabilities in the repository<br />\" --context publish --append : echo fs scan success" \
-    "annotate --style success \"trivy didn't find any relevant vulnerabilities in the container image<br />\" --context publish --append : echo container image scan success" \
+  stub buildkite-agent "annotate --style success \"trivy didn't find any relevant vulnerabilities in the repository<br />\" --context trivy-fs-scan : echo fs scan success" \
+    "annotate --style success \"trivy didn't find any relevant vulnerabilities in the container image<br />\" --context trivy-container-scan : echo container image scan success" \
 
   run "$PWD/hooks/post-command"
 


### PR DESCRIPTION
This enables the scan to output multiple annotations instead of
appending the output. This enables us to clearly portray to folks that
an fs scan failed while the image scan didn't or viceversa.

This also now uses a unique value for the annotation's context. One for the
filesystem scan (`trivy-fs-scan`) one for the container scan
(`trivy-container-scan`), and finally a catch-all context for "other"
failures or messages (`trivy-scan`).

For more info, look at the buildkite docs: https://buildkite.com/docs/agent/v3/cli-annotate

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
