### PR TITLE
Add `release` Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,14 @@ BUILDKITE_TESTER_IMAGE=buildkite/plugin-tester:v2.0.0
 #                  we should ask for a fix.
 BUILDKITE_LINTER_IMAGE=buildkite/plugin-linter:latest
 
+PLUGIN_REF=equinixmetal-buildkite/trivy
+
+# Must be set before doing a release
+TAG?=
+
 .PHONY: lint
 lint: | plugin-arg-docs
-	docker run --rm -v "$$PWD:/plugin:ro" $(BUILDKITE_LINTER_IMAGE) --id equinixmetal-buildkite/trivy
+	docker run --rm -v "$$PWD:/plugin:ro" $(BUILDKITE_LINTER_IMAGE) --id $(PLUGIN_REF)
 
 .PHONY: test
 test:
@@ -17,3 +22,14 @@ plugin-arg-docs: ## Ensures that the plugin arguments are documented
 	@echo "Checking that all properties are documented in the README"
 	@yq '.configuration.properties | keys' plugin.yml | awk '{print $$2}' | xargs -n1 -I % grep -qE "### \`%\`" README.md || \
 		{ echo "All properties must be documented in the README"; exit 1; }
+
+.PHONY: release
+release: ## Issues a release
+	@test -n "$(TAG)" || (echo "The TAG variable must be set" && exit 1)
+	@echo "Releasing $(TAG)"
+	git checkout -b "$(TAG)"
+	sed -i "s%$(PLUGIN_REF).*:%$(PLUGIN_REF)#$(TAG):%" README.md
+	git add README.md
+	git commit -m "Release $(TAG)"
+	git tag "$(TAG)"
+	git push --follow-tags origin "$(TAG)"

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ step with the default plugin configuration parameters:
 steps:
   - command: ls
     plugins:
-      - equinixmetal-buildkite/trivy#v1.15.0: ~
+      - equinixmetal-buildkite/trivy#v1.15.0:
 ```
 
 ## Additional examples
@@ -37,7 +37,7 @@ steps:
   - command: ls
     plugins:
       - equinixmetal-buildkite/trivy#v1.15.0:
-        exit-code: 1
+          exit-code: 1
 ```
 
 Specify the `--severity` option as a plugin parameter in `pipeline.yml` to scan specific type of vulnerabilities. Below is an example for scanning `CRITICAL` vulnerabilities:
@@ -47,7 +47,7 @@ steps:
   - command: ls
     plugins:
       - equinixmetal-buildkite/trivy#v1.15.0:
-        severity: "CRITICAL"
+          severity: "CRITICAL"
 ```
 
 ## Configuration


### PR DESCRIPTION
This effectively does a release by doing e.g. `TAG=v1.15.2 make release`.

Under the hood, this will create a new branch with the same name as the
tag, edit the README.md with examples that follow the appropriate
version, tag the new commit, and finally, push both the branch and tag
to the repository.

Note that this also fixes the examples which were wrongly formatted.

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
