### PR TITLE
Fix `make release` to work with older git versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,9 +27,10 @@ plugin-arg-docs: ## Ensures that the plugin arguments are documented
 release: ## Issues a release
 	@test -n "$(TAG)" || (echo "The TAG variable must be set" && exit 1)
 	@echo "Releasing $(TAG)"
-	git checkout -b "$(TAG)"
+	git checkout -b "release-$(TAG)"
 	sed -i "s%$(PLUGIN_REF).*:%$(PLUGIN_REF)#$(TAG):%" README.md
 	git add README.md
 	git commit -m "Release $(TAG)"
-	git tag "$(TAG)"
-	git push --follow-tags origin "$(TAG)"
+	git tag -m "Release $(TAG)" "$(TAG)"
+	git push origin "release-$(TAG)"
+	git push origin "$(TAG)"


### PR DESCRIPTION
`--follow-tags` required a newer git version. This fixes the process by
using a branch named differently as the tag and pushing both to make
things work.

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
