### PR TITLE
Enable debug logging driven by a makefile flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,13 +9,21 @@ PLUGIN_REF=equinixmetal-buildkite/trivy
 # Must be set before doing a release
 TAG?=
 
+# Enable debug logging for plugin-tester image
+TEST_DEBUG?=
+ifdef TEST_DEBUG
+	TTY_FLAG = -t
+else
+	TTY_FLAG =
+endif
+
 .PHONY: lint
 lint: | plugin-arg-docs
 	docker run --rm -v "$$PWD:/plugin:ro" $(BUILDKITE_LINTER_IMAGE) --id $(PLUGIN_REF)
 
 .PHONY: test
 test:
-	docker run --rm -v "$$PWD:/plugin:ro" $(BUILDKITE_TESTER_IMAGE)
+	docker run --rm $(TTY_FLAG) -v "$$PWD:/plugin:ro" $(BUILDKITE_TESTER_IMAGE)
 
 .PHONY: plugin-arg-docs
 plugin-arg-docs: ## Ensures that the plugin arguments are documented

--- a/README.md
+++ b/README.md
@@ -85,3 +85,25 @@ To run the tests:
 ```shell
 make test
 ```
+
+Run the tests with debug logging enabled:
+
+```shell
+TEST_DEBUG=1 make test
+```
+
+To enable debug logging for a stubbed command in the test, you need to set or
+uncomment the export for the necessary command in the `.bats` file.
+
+e.g. to view the debug logging for the `trivy` command, set the following
+at the top of the `.bats` file:
+
+```shell
+export TRIVY_STUB_DEBUG=/dev/tty
+```
+
+and then run the tests with debug logging enabled:
+
+```shell
+TEST_DEBUG=1 make test
+```


### PR DESCRIPTION
This enables the usage of the `TEST_DEBUG` variable/flag in order to
enable debug logging for tests.

Instructions for this were added to the README. But the gist is that you
can now do:

```shell
TEST_DEBUG=1 make test
```

To enable such a thing.

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
