### PR TITLE
pre-checkout: Ensure TRIVY_EXE_PATH is set.

### DIFF
--- a/hooks/pre-checkout
+++ b/hooks/pre-checkout
@@ -255,6 +255,7 @@ WHICH_TRIVY_EXE="$(which trivy)"
 # shellcheck disable=SC2181
 if [[ "$?" -eq 0 ]] && [[ -f "${WHICH_TRIVY_EXE}" ]]; then
   echo "${WHICH_TRIVY_EXE}"
+  export TRIVY_EXE_PATH="${WHICH_TRIVY_EXE}"
   exit 0
 fi
 


### PR DESCRIPTION
I forgot to set the TRIVY_EXE_PATH environment variable when we find trivy in one of the PATH directories using "which". As a result, the plugin would fail if it discovered an existing trivy executable.