### PR TITLE
Add `skip-files` and `skip-dirs` options

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,14 @@ Controls whether to display only fixed vulnerabilities. (Defaults to false)
 
 Controls the security checks to be performed. (Defaults to "vuln,config")
 
+### `skip-files` (Optional, string)
+
+Controls the files to be skipped during the scan. (Defaults to "")
+
+### `skip-dirs` (Optional, string)
+
+Controls the directories to be skipped during the scan. (Defaults to "")
+
 ### `image-ref` (Optional, string)
 
 **Important**: Please ensure the target Docker image is built prior to the trivy plugin running when using this option. The trivy plugin does not build Docker images; it only scans existing images.

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -90,6 +90,16 @@ else
   fsargs+=("--security-checks" "vuln,config")
 fi
 
+if [[ -n "${BUILDKITE_PLUGIN_TRIVY_SKIP_FILES:-}" ]] ; then
+  fsargs+=("--skip-files" "${BUILDKITE_PLUGIN_TRIVY_SKIP_FILES}")
+  echo "skipping files '$BUILDKITE_PLUGIN_TRIVY_SKIP_FILES' from scan "
+fi
+
+if [[ -n "${BUILDKITE_PLUGIN_TRIVY_SKIP_DIRS:-}" ]] ; then
+  fsargs+=("--skip-dirs" "${BUILDKITE_PLUGIN_TRIVY_SKIP_DIRS}")
+  echo "skipping directories '$BUILDKITE_PLUGIN_TRIVY_SKIP_DIRS' from scan "
+fi
+
 echo "--- scanning filesystem"
 trivy fs "${args[@]}" "${fsargs[@]}" .
 # Status gets overwritten by the next scan, so we save it here

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,6 +1,6 @@
 name: Trivy
-description: Trivy FS Scan
-author: Hari
+description: Trivy Security Scanning
+author: Equinix Metal
 requirements:
   - bash
   - docker
@@ -21,5 +21,9 @@ configuration:
     security-checks:
       type: string
     image-ref:
+      type: string
+    skip-files:
+      type: string
+    skip-dirs:
       type: string
   additionalProperties: false

--- a/tests/post-command.bats
+++ b/tests/post-command.bats
@@ -201,6 +201,32 @@ default_exit_code="--exit-code 1"
   unstub buildkite-agent
 }
 
+@test "fs scan of a test app skipping a file" {
+  export BUILDKITE_PLUGIN_TRIVY_SKIP_FILES="test.txt"
+  stub trivy "fs $default_exit_code --skip-files $BUILDKITE_PLUGIN_TRIVY_SKIP_FILES . : echo fs scan success"
+  stub buildkite-agent "annotate --style success \"trivy didn't find any relevant vulnerabilities in the repository<br />\" --context trivy-fs-scan : echo fs scan success" \
+    "annotate --style success \"No container image was scanned due to a lack of an image reference. This is fine.<br />\" --context trivy-container-scan : echo no image scan happened" \
+
+  run "$PWD/hooks/post-command"
+
+  assert_success
+  assert_output --partial "scanning filesystem"
+  assert_output --partial "skipping files '$BUILDKITE_PLUGIN_TRIVY_SKIP_FILES' from scan"
+}
+
+@test "fs scan of a test app skipping a dir" {
+  export BUILDKITE_PLUGIN_TRIVY_SKIP_DIRS="test"
+  stub trivy "fs $default_exit_code --skip-dirs $BUILDKITE_PLUGIN_TRIVY_SKIP_DIRS . : echo fs scan success"
+  stub buildkite-agent "annotate --style success \"trivy didn't find any relevant vulnerabilities in the repository<br />\" --context trivy-fs-scan : echo fs scan success" \
+    "annotate --style success \"No container image was scanned due to a lack of an image reference. This is fine.<br />\" --context trivy-container-scan : echo no image scan happened" \
+
+  run "$PWD/hooks/post-command"
+
+  assert_success
+  assert_output --partial "scanning filesystem"
+  assert_output --partial "skipping directories '$BUILDKITE_PLUGIN_TRIVY_SKIP_DIRS' from scan"
+}
+
 @test "scan of image reference not present locally" {
   export BUILDKITE_PLUGIN_TRIVY_IMAGE_REF="nginx:latest"
 


### PR DESCRIPTION
This controls what files and directories should be skipped during the
scan.

This is useful for skipping temporary files used only for signing
containers.

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
