### PR TITLE
Helm overrides for Trivy buildkite plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,11 @@ Controls the image reference to be scanned. If no image is specified, the image 
 
 Controls the version of trivy to be used.
 
+### `helm-overrides` (Optional, string)
+
+To pass helm override values to trivy config scan
+
+
 ## Developing
 
 To run the tests:

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Controls the image reference to be scanned. If no image is specified, the image 
 
 Controls the version of trivy to be used.
 
-### `helm-overrides` (Optional, string)
+### `helm-overrides-file` (Optional, string)
 
 To pass helm override values to trivy config scan
 

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -72,22 +72,9 @@ final_exit_code="${BUILDKITE_PLUGIN_TRIVY_EXIT_CODE:-1}"
 args+=("--exit-code" "$final_exit_code")
 echo "using exit-code=$final_exit_code option while scanning"
 
-if [[ "${BUILDKITE_PLUGIN_TRIVY_IGNORE_UNFIXED:-false}" == true ]] ; then
-  args+=("--ignore-unfixed")
-  echo "ignore-unfixed is set. Will ignore unfixed vulnerabilities"
-fi
-
 if [[ -n "${BUILDKITE_PLUGIN_TRIVY_SEVERITY:-}" ]] ; then
   args+=("--severity" "${BUILDKITE_PLUGIN_TRIVY_SEVERITY}")
   echo "using non-default severity types"
-fi
-
-if [[ -n "${BUILDKITE_PLUGIN_TRIVY_SECURITY_CHECKS:-}" ]] ; then
-  fsargs+=("--security-checks" "${BUILDKITE_PLUGIN_TRIVY_SECURITY_CHECKS}")
-  echo "using $BUILDKITE_PLUGIN_TRIVY_SECURITY_CHECKS security checks"
-else
-  echo "using default security checks"
-  fsargs+=("--security-checks" "vuln,config")
 fi
 
 if [[ -n "${BUILDKITE_PLUGIN_TRIVY_SKIP_FILES:-}" ]] ; then
@@ -98,6 +85,24 @@ fi
 if [[ -n "${BUILDKITE_PLUGIN_TRIVY_SKIP_DIRS:-}" ]] ; then
   fsargs+=("--skip-dirs" "${BUILDKITE_PLUGIN_TRIVY_SKIP_DIRS}")
   echo "skipping directories '$BUILDKITE_PLUGIN_TRIVY_SKIP_DIRS' from scan "
+fi
+
+if [[ -n "${BUILDKITE_PLUGIN_TRIVY_HELM_OVERRIDES_FILE:-}" ]]; then
+	echo "scanning with helm overrides"
+	trivy conf --helm-values helm-overrides.yaml "${args[@]}" "${fsargs[@]}" .
+fi
+
+if [[ "${BUILDKITE_PLUGIN_TRIVY_IGNORE_UNFIXED:-false}" == true ]] ; then
+  args+=("--ignore-unfixed")
+  echo "ignore-unfixed is set. Will ignore unfixed vulnerabilities"
+fi
+
+if [[ -n "${BUILDKITE_PLUGIN_TRIVY_SECURITY_CHECKS:-}" ]] ; then
+  fsargs+=("--security-checks" "${BUILDKITE_PLUGIN_TRIVY_SECURITY_CHECKS}")
+  echo "using $BUILDKITE_PLUGIN_TRIVY_SECURITY_CHECKS security checks"
+else
+  echo "using default security checks"
+  fsargs+=("--security-checks" "vuln,config")
 fi
 
 echo "+++ scanning filesystem"

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -89,7 +89,7 @@ fi
 
 if [[ -n "${BUILDKITE_PLUGIN_TRIVY_HELM_OVERRIDES_FILE:-}" ]]; then
 	echo "scanning with helm overrides"
-	trivy conf --helm-values helm-overrides.yaml "${args[@]}" "${fsargs[@]}" .
+	trivy conf --helm-values "${BUILDKITE_PLUGIN_TRIVY_HELM_OVERRIDES_FILE} "${args[@]}" "${fsargs[@]}" .
 fi
 
 if [[ "${BUILDKITE_PLUGIN_TRIVY_IGNORE_UNFIXED:-false}" == true ]] ; then

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -89,7 +89,7 @@ fi
 
 if [[ -n "${BUILDKITE_PLUGIN_TRIVY_HELM_OVERRIDES_FILE:-}" ]]; then
 	echo "scanning with helm overrides"
-	trivy conf --helm-values "${BUILDKITE_PLUGIN_TRIVY_HELM_OVERRIDES_FILE} "${args[@]}" "${fsargs[@]}" .
+	trivy conf --helm-values "${BUILDKITE_PLUGIN_TRIVY_HELM_OVERRIDES_FILE}" "${args[@]}" "${fsargs[@]}" .
 fi
 
 if [[ "${BUILDKITE_PLUGIN_TRIVY_IGNORE_UNFIXED:-false}" == true ]] ; then

--- a/plugin.yml
+++ b/plugin.yml
@@ -26,4 +26,6 @@ configuration:
       type: string
     skip-dirs:
       type: string
+    helm-overrides-file:
+      type: string 
   additionalProperties: false


### PR DESCRIPTION
- In this PR we are adding a property on trivy buildkite plugin to accept `overrides.yaml `file and run `trivy conf --helm-values overrides.yaml` before doing the trivy scan.