### PR TITLE
timeout: Initial argument support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,11 @@ steps:
 
 Controls whether the security scan is blocking or not. This is done by setting the exit code of the plugin. If the exit code is set to 0, the pipeline will continue. If the exit code is set to 1, the pipeline will fail. (Defaults to 0)
 
+### `timeout` (Optional, string)
+
+Controls the maximum amount of time a scan will run for by passing the
+`--timeout` argument to trivy.
+
 ### `severity` (Optional, string)
 
 Controls the severity of the vulnerabilities to be scanned. (Defaults to "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL")

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -72,6 +72,11 @@ final_exit_code="${BUILDKITE_PLUGIN_TRIVY_EXIT_CODE:-1}"
 args+=("--exit-code" "$final_exit_code")
 echo "using exit-code=$final_exit_code option while scanning"
 
+if [[ -n "${BUILDKITE_PLUGIN_TRIVY_TIMEOUT:-}" ]] ; then
+  args+=("--timeout" "${BUILDKITE_PLUGIN_TRIVY_TIMEOUT}")
+  echo "using non-default timeout: '${BUILDKITE_PLUGIN_TRIVY_TIMEOUT}'"
+fi
+
 if [[ -n "${BUILDKITE_PLUGIN_TRIVY_SEVERITY:-}" ]] ; then
   args+=("--severity" "${BUILDKITE_PLUGIN_TRIVY_SEVERITY}")
   echo "using non-default severity types"


### PR DESCRIPTION
Control+F "--timeout":

https://aquasecurity.github.io/trivy/v0.36/docs/references/cli/