### PR TITLE
update correctly readme.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ steps:
 
 ## Configuration
 
-### `exit-code` (Optional, array)
+### `exit-code` (Optional, integer)
 
 Controls whether the security scan is blocking or not. This is done by setting the exit code of the plugin. If the exit code is set to 0, the pipeline will continue. If the exit code is set to 1, the pipeline will fail. (Defaults to 0)
 


### PR DESCRIPTION
As per this line the exit-code is integer and not array so, I've updated correctly readme file.

```https://github.com/equinixmetal-buildkite/trivy-buildkite-plugin/blob/main/plugin.yml#L13```([plugin.yml](https://github.com/equinixmetal-buildkite/trivy-buildkite-plugin/blob/main/plugin.yml#L13))
