### PR TITLE
Use fsargs for helm scans instead of running a config check

### DIFF
--- a/hooks/post-command
+++ b/hooks/post-command
@@ -93,8 +93,8 @@ if [[ -n "${BUILDKITE_PLUGIN_TRIVY_SKIP_DIRS:-}" ]] ; then
 fi
 
 if [[ -n "${BUILDKITE_PLUGIN_TRIVY_HELM_OVERRIDES_FILE:-}" ]]; then
+	fsargs+=("--helm-values" "${BUILDKITE_PLUGIN_TRIVY_HELM_OVERRIDES_FILE}")
 	echo "scanning with helm overrides"
-	trivy conf --helm-values "${BUILDKITE_PLUGIN_TRIVY_HELM_OVERRIDES_FILE}" "${args[@]}" "${fsargs[@]}" .
 fi
 
 if [[ "${BUILDKITE_PLUGIN_TRIVY_IGNORE_UNFIXED:-false}" == true ]] ; then


### PR DESCRIPTION
It looks like the plugin is doing a direct config scan if the helm overrides is passed, which means the scan will then fail when the fs scan runs. I don't think this is the desired behavior and the overrides flag should be passed to the fs scan.