### PR TITLE
downgrade trivy to v0.54.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ with the default plugin configuration parameters:
 steps:
   - command: ls
     plugins:
-      - equinixmetal-buildkite/trivy#v1.18.5:
+      - equinixmetal-buildkite/trivy#v1.19.1:
 ```
 
 ## Additional examples
@@ -37,7 +37,7 @@ the pipeline when there are vulnerabilities:
 steps:
   - command: ls
     plugins:
-      - equinixmetal-buildkite/trivy#v1.18.5:
+      - equinixmetal-buildkite/trivy#v1.19.1:
           exit-code: 1
 ```
 
@@ -49,7 +49,7 @@ vulnerabilities:
 steps:
   - command: ls
     plugins:
-      - equinixmetal-buildkite/trivy#v1.18.5:
+      - equinixmetal-buildkite/trivy#v1.19.1:
           severity: "CRITICAL"
 ```
 

--- a/hooks/pre-checkout
+++ b/hooks/pre-checkout
@@ -29,7 +29,7 @@
 # - which
 # - mkdir
 
-readonly TRIVY_DEFAULT_VERSION="0.55.2"
+readonly TRIVY_DEFAULT_VERSION="0.54.1"
 export TRIVY_VERSION="${BUILDKITE_PLUGIN_TRIVY_TRIVY_VERSION:-$TRIVY_DEFAULT_VERSION}"
 REMOVE_FILE_ON_ERR=""
 
@@ -49,7 +49,7 @@ display_error() {
 # environment and uses it to build the OS and CPU string that
 # appears in each trivy release's file name.
 #
-# For example, the string for "trivy_0.31.3_FreeBSD-32bit.tar.gz" 
+# For example, the string for "trivy_0.31.3_FreeBSD-32bit.tar.gz"
 # would be "FreeBSD-32bit".
 trivy_os_cpu_string() {
   local UNAME_INFO=""


### PR DESCRIPTION
this pr downgrades trivy back to `v0.54.1`

background:

i think i found a bug in trivy that is causing the `file does not exist` issue we seen while scanning helm charts with with newer (ie, 0.55.2) trivy versions - tl;dr:
- helm parser calls ParseFS() [recursively](https://github.com/aquasecurity/trivy/blob/9514148767865baddd73a49245385574927f7a74/pkg/iac/scanners/helm/parser/parser.go#L112) that in turn [uses](https://github.com/aquasecurity/trivy/blob/9514148767865baddd73a49245385574927f7a74/pkg/iac/scanners/helm/parser/parser.go#L85-L85) fs.WalkDir() which is also recursive
- once an archive is processed, it gets [removed](https://github.com/aquasecurity/trivy/blob/9514148767865baddd73a49245385574927f7a74/pkg/iac/scanners/helm/parser/parser_tar.go#L101) from the memoryfs.FS
- now, while returning from recursive calls, the "parent" caller might try to process archive that was previously known to fs.WalkDir() to exist, but the "child" might have already processed and removed it
- so, we'd need to detect and skip those

the bug was probably introduced in commit [e95152f](https://github.com/aquasecurity/trivy/commit/e95152f796308c25aaaa6cf75b2e7a81b3ab4388), where a check was [removed](https://github.com/aquasecurity/trivy/commit/e95152f796308c25aaaa6cf75b2e7a81b3ab4388#diff-a8b46bcbae1373c8cfdcc22b2cd2d476644574ea2ff4cc71e24ef2c484773922L132-L135), which further means that it was probably introduced in trivy v0.55.0 but it was working in v0.54.1

next steps:
- we could revert/update our buildkite plugin to use trivy v0.54.1 (this pr)
- i'll look into proposing a pr to fix this upstream, but their process for that is a bit tedious (you cannot open an issue/pr, you have to go through discussions first)