### PR TITLE
Add kube version argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,10 @@ To pass helm override values to trivy config scan
 
 Enable debug flag for trivy.
 
+### `kube-version` (Optional, string)
+
+Sets the `helm-kube-version` passed to trivy.
+
 ## Developing
 
 To run the tests:

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -112,6 +112,11 @@ if [[ "${BUILDKITE_PLUGIN_TRIVY_IGNORE_UNFIXED:-false}" == true ]] ; then
   echo "ignore-unfixed is set. Will ignore unfixed vulnerabilities"
 fi
 
+if [[ -n "${BUILDKITE_PLUGIN_TRIVY_KUBE_VERSION:-}" ]] ; then
+  fsargs+=("--helm-kube-version" "${BUILDKITE_PLUGIN_TRIVY_KUBE_VERSION}")
+  echo "using non-default kube-version"
+fi
+
 if [[ -n "${BUILDKITE_PLUGIN_TRIVY_SCANNERS:-}" ]] ; then
   fsargs+=("--scanners" "${BUILDKITE_PLUGIN_TRIVY_SCANNERS}")
   echo "using $BUILDKITE_PLUGIN_TRIVY_SCANNERS scanners"

--- a/plugin.yml
+++ b/plugin.yml
@@ -34,4 +34,6 @@ configuration:
       type: string
     debug:
       type: boolean
+    kube-version
+      type: string
   additionalProperties: false

--- a/plugin.yml
+++ b/plugin.yml
@@ -34,6 +34,6 @@ configuration:
       type: string
     debug:
       type: boolean
-    kube-version
+    kube-version:
       type: string
   additionalProperties: false


### PR DESCRIPTION
trivy has a `helm-kube-version` which by default is currently 1.20. When scanning charts if the chart has a minimum chart version higher than the `helm-kube-version` the scan returns an error.

trivy supports setting this version with `--helm-kube-version`. This pull request adds the ability to set `--helm-kube-version` in the plugin for example:
```
- label: ":trivy: scan"
  command: "echo '--- Running the Trivy security scanner'"
  plugins:
    - equinixmetail-buildkite/trivy#v1.20.0:
        kube-version: "1.21"
```

