### PR TITLE
Use a default helm kube version of 1.30

### DIFF
--- a/hooks/post-command
+++ b/hooks/post-command
@@ -112,10 +112,10 @@ if [[ "${BUILDKITE_PLUGIN_TRIVY_IGNORE_UNFIXED:-false}" == true ]] ; then
   echo "ignore-unfixed is set. Will ignore unfixed vulnerabilities"
 fi
 
-if [[ -n "${BUILDKITE_PLUGIN_TRIVY_KUBE_VERSION:-}" ]] ; then
-  fsargs+=("--helm-kube-version" "${BUILDKITE_PLUGIN_TRIVY_KUBE_VERSION}")
-  echo "using non-default kube-version"
-fi
+# Set the helm kube version to a recent default or allow user to override
+helm_kube_version="${BUILDKITE_PLUGIN_TRIVY_KUBE_VERSION:-1.30}"
+fsargs+=("--helm-kube-version" "${helm_kube_version}")
+echo "using helm kube version ${helm_kube_version}"
 
 if [[ -n "${BUILDKITE_PLUGIN_TRIVY_SCANNERS:-}" ]] ; then
   fsargs+=("--scanners" "${BUILDKITE_PLUGIN_TRIVY_SCANNERS}")

--- a/tests/post-command.bats
+++ b/tests/post-command.bats
@@ -5,13 +5,14 @@ load "$BATS_PLUGIN_PATH/load.bash"
 export TRIVY_EXE_PATH="$(mktemp)"
 
 default_exit_code="--exit-code 1"
+default_helm_kube_version="1.30"
 
 # Uncomment the following line to debug stub failures
 # export BUILDKITE_AGENT_STUB_DEBUG=/dev/tty
 
 @test "fs scan of a test app" {
   # TODO(jaosorior): Change the exit code if we change the default
-  stub trivy "fs $default_exit_code --scanners vuln,misconfig . : echo fs scan success"
+  stub trivy "fs $default_exit_code --helm-kube-version $default_helm_kube_version --scanners vuln,misconfig . : echo fs scan success"
   stub buildkite-agent "annotate --style success \"trivy didn't find any relevant vulnerabilities in the repository<br />\" --context trivy-fs-scan : echo fs scan success" \
     "annotate --style success \"No container image was scanned due to a lack of an image reference. This is fine.<br />\" --context trivy-container-scan : echo no image scan happened" \
 
@@ -29,7 +30,7 @@ default_exit_code="--exit-code 1"
 @test "fs scan of a test app with exit-code=1" {
   export BUILDKITE_PLUGIN_TRIVY_EXIT_CODE=1
 
-  stub trivy "fs --exit-code 1 --scanners vuln,misconfig . : echo fs scan success"
+  stub trivy "fs --exit-code 1 --helm-kube-version $default_helm_kube_version --scanners vuln,misconfig . : echo fs scan success"
   stub buildkite-agent "annotate --style success \"trivy didn't find any relevant vulnerabilities in the repository<br />\" --context trivy-fs-scan : echo fs scan success" \
     "annotate --style success \"No container image was scanned due to a lack of an image reference. This is fine.<br />\" --context trivy-container-scan : echo no image scan happened" \
 
@@ -47,7 +48,7 @@ default_exit_code="--exit-code 1"
 @test "fs scan of a test app with exit-code=0" {
   export BUILDKITE_PLUGIN_TRIVY_EXIT_CODE=0
 
-  stub trivy "fs --exit-code 0 --scanners vuln,misconfig . : echo fs scan success"
+  stub trivy "fs --exit-code 0 --helm-kube-version $default_helm_kube_version --scanners vuln,misconfig . : echo fs scan success"
   stub buildkite-agent "annotate --style success \"trivy didn't find any relevant vulnerabilities in the repository<br />\" --context trivy-fs-scan : echo fs scan success" \
     "annotate --style success \"No container image was scanned due to a lack of an image reference. This is fine.<br />\" --context trivy-container-scan : echo no image scan happened" \
 
@@ -65,7 +66,7 @@ default_exit_code="--exit-code 1"
 @test "fs scan of a test app with exit-code=1 with actual failure" {
   export BUILDKITE_PLUGIN_TRIVY_EXIT_CODE=1
 
-  stub trivy "fs --exit-code 1 --scanners vuln,misconfig . : exit 1"
+  stub trivy "fs --exit-code 1 --helm-kube-version $default_helm_kube_version --scanners vuln,misconfig . : exit 1"
   stub buildkite-agent "annotate --style error \"trivy found vulnerabilities in repository. See the job output for details.<br />\" --context trivy-fs-scan : echo fs scan failure" \
     "annotate --style success \"No container image was scanned due to a lack of an image reference. This is fine.<br />\" --context trivy-container-scan : echo no image scan happened" \
 
@@ -83,7 +84,7 @@ default_exit_code="--exit-code 1"
 @test "fs scan of test app with ignore-unfixed flag set" {
   export BUILDKITE_PLUGIN_TRIVY_IGNORE_UNFIXED=true
 
-  stub trivy "fs $default_exit_code --ignore-unfixed --scanners vuln,misconfig . : echo fs scan success with --ignore-unfixed"
+  stub trivy "fs $default_exit_code --ignore-unfixed --helm-kube-version $default_helm_kube_version --scanners vuln,misconfig . : echo fs scan success with --ignore-unfixed"
   stub buildkite-agent "annotate --style success \"trivy didn't find any relevant vulnerabilities in the repository<br />\" --context trivy-fs-scan : echo output success" \
     "annotate --style success \"No container image was scanned due to a lack of an image reference. This is fine.<br />\" --context trivy-container-scan : echo no image scan happened" \
 
@@ -103,7 +104,7 @@ default_exit_code="--exit-code 1"
   export BUILDKITE_PLUGIN_TRIVY_TIMEOUT="6h6m6s"
   export BUILDKITE_PLUGIN_TRIVY_EXIT_CODE=1
 
-  stub trivy "fs --exit-code 1 --timeout $BUILDKITE_PLUGIN_TRIVY_TIMEOUT --scanners vuln,misconfig . : echo fs scan success"
+  stub trivy "fs --exit-code 1 --timeout $BUILDKITE_PLUGIN_TRIVY_TIMEOUT --helm-kube-version $default_helm_kube_version --scanners vuln,misconfig . : echo fs scan success"
   stub buildkite-agent "annotate --style success \"trivy didn't find any relevant vulnerabilities in the repository<br />\" --context trivy-fs-scan : echo fs scan success" \
     "annotate --style success \"No container image was scanned due to a lack of an image reference. This is fine.<br />\" --context trivy-container-scan : echo no image scan happened" \
 
@@ -121,7 +122,7 @@ default_exit_code="--exit-code 1"
   export BUILDKITE_PLUGIN_TRIVY_SEVERITY="CRITICAL"
   export BUILDKITE_PLUGIN_TRIVY_EXIT_CODE=1
 
-  stub trivy "fs --exit-code 1 --severity $BUILDKITE_PLUGIN_TRIVY_SEVERITY --scanners vuln,misconfig . : echo fs scan success"
+  stub trivy "fs --exit-code 1 --severity $BUILDKITE_PLUGIN_TRIVY_SEVERITY --helm-kube-version $default_helm_kube_version --scanners vuln,misconfig . : echo fs scan success"
   stub buildkite-agent "annotate --style success \"trivy didn't find any relevant vulnerabilities in the repository<br />\" --context trivy-fs-scan : echo fs scan success" \
     "annotate --style success \"No container image was scanned due to a lack of an image reference. This is fine.<br />\" --context trivy-container-scan : echo no image scan happened" \
 
@@ -139,7 +140,7 @@ default_exit_code="--exit-code 1"
   export BUILDKITE_PLUGIN_TRIVY_SEVERITY="CRITICAL,HIGH"
   export BUILDKITE_PLUGIN_TRIVY_EXIT_CODE=1
 
-  stub trivy "fs --exit-code 1 --severity $BUILDKITE_PLUGIN_TRIVY_SEVERITY --scanners vuln,misconfig . : echo fs scan success"
+  stub trivy "fs --exit-code 1 --severity $BUILDKITE_PLUGIN_TRIVY_SEVERITY --helm-kube-version $default_helm_kube_version --scanners vuln,misconfig . : echo fs scan success"
   stub buildkite-agent "annotate --style success \"trivy didn't find any relevant vulnerabilities in the repository<br />\" --context trivy-fs-scan : echo fs scan success" \
     "annotate --style success \"No container image was scanned due to a lack of an image reference. This is fine.<br />\" --context trivy-container-scan : echo no image scan happened" \
 
@@ -157,7 +158,7 @@ default_exit_code="--exit-code 1"
   export BUILDKITE_PLUGIN_TRIVY_SEVERITY="CRITICAL,HIGH,MEDIUM"
   export BUILDKITE_PLUGIN_TRIVY_EXIT_CODE=1
 
-  stub trivy "fs --exit-code 1 --severity $BUILDKITE_PLUGIN_TRIVY_SEVERITY --scanners vuln,misconfig . : echo fs scan success"
+  stub trivy "fs --exit-code 1 --severity $BUILDKITE_PLUGIN_TRIVY_SEVERITY --helm-kube-version $default_helm_kube_version --scanners vuln,misconfig . : echo fs scan success"
   stub buildkite-agent "annotate --style success \"trivy didn't find any relevant vulnerabilities in the repository<br />\" --context trivy-fs-scan : echo fs scan success" \
     "annotate --style success \"No container image was scanned due to a lack of an image reference. This is fine.<br />\" --context trivy-container-scan : echo no image scan happened" \
 
@@ -173,7 +174,7 @@ default_exit_code="--exit-code 1"
 
 @test "fs scan of a test app with only vulnerbility scanner" {
   export BUILDKITE_PLUGIN_TRIVY_SCANNERS="vuln"
-  stub trivy "fs $default_exit_code --scanners $BUILDKITE_PLUGIN_TRIVY_SCANNERS . : echo fs scan success"
+  stub trivy "fs $default_exit_code --helm-kube-version $default_helm_kube_version --scanners $BUILDKITE_PLUGIN_TRIVY_SCANNERS . : echo fs scan success"
   stub buildkite-agent "annotate --style success \"trivy didn't find any relevant vulnerabilities in the repository<br />\" --context trivy-fs-scan : echo fs scan success" \
     "annotate --style success \"No container image was scanned due to a lack of an image reference. This is fine.<br />\" --context trivy-container-scan : echo no image scan happened" \
 
@@ -189,7 +190,7 @@ default_exit_code="--exit-code 1"
 
 @test "fs scan of a test app with vulnerbility and configuration scanners" {
   export BUILDKITE_PLUGIN_TRIVY_SCANNERS="vuln,misconfig"
-  stub trivy "fs $default_exit_code --scanners $BUILDKITE_PLUGIN_TRIVY_SCANNERS . : echo fs scan success"
+  stub trivy "fs $default_exit_code --helm-kube-version $default_helm_kube_version --scanners $BUILDKITE_PLUGIN_TRIVY_SCANNERS . : echo fs scan success"
   stub buildkite-agent "annotate --style success \"trivy didn't find any relevant vulnerabilities in the repository<br />\" --context trivy-fs-scan : echo fs scan success" \
     "annotate --style success \"No container image was scanned due to a lack of an image reference. This is fine.<br />\" --context trivy-container-scan : echo no image scan happened" \
 
@@ -205,7 +206,7 @@ default_exit_code="--exit-code 1"
 
 @test "fs scan of a test app with vulnerbility,secret and configuration scanners" {
   export BUILDKITE_PLUGIN_TRIVY_SCANNERS="vuln,secret,misconfig"
-  stub trivy "fs $default_exit_code --scanners $BUILDKITE_PLUGIN_TRIVY_SCANNERS . : echo fs scan success"
+  stub trivy "fs $default_exit_code --helm-kube-version $default_helm_kube_version --scanners $BUILDKITE_PLUGIN_TRIVY_SCANNERS . : echo fs scan success"
   stub buildkite-agent "annotate --style success \"trivy didn't find any relevant vulnerabilities in the repository<br />\" --context trivy-fs-scan : echo fs scan success" \
     "annotate --style success \"No container image was scanned due to a lack of an image reference. This is fine.<br />\" --context trivy-container-scan : echo no image scan happened" \
 
@@ -221,7 +222,7 @@ default_exit_code="--exit-code 1"
 
 @test "fs scan of a test app skipping a file" {
   export BUILDKITE_PLUGIN_TRIVY_SKIP_FILES="test.txt"
-  stub trivy "fs $default_exit_code --skip-files $BUILDKITE_PLUGIN_TRIVY_SKIP_FILES --scanners vuln,misconfig . : echo fs scan success"
+  stub trivy "fs $default_exit_code --skip-files $BUILDKITE_PLUGIN_TRIVY_SKIP_FILES --helm-kube-version $default_helm_kube_version --scanners vuln,misconfig . : echo fs scan success"
   stub buildkite-agent "annotate --style success \"trivy didn't find any relevant vulnerabilities in the repository<br />\" --context trivy-fs-scan : echo fs scan success" \
     "annotate --style success \"No container image was scanned due to a lack of an image reference. This is fine.<br />\" --context trivy-container-scan : echo no image scan happened" \
 
@@ -234,7 +235,7 @@ default_exit_code="--exit-code 1"
 
 @test "fs scan of a test app skipping a dir" {
   export BUILDKITE_PLUGIN_TRIVY_SKIP_DIRS="test"
-  stub trivy "fs $default_exit_code --skip-dirs $BUILDKITE_PLUGIN_TRIVY_SKIP_DIRS --scanners vuln,misconfig . : echo fs scan success"
+  stub trivy "fs $default_exit_code --skip-dirs $BUILDKITE_PLUGIN_TRIVY_SKIP_DIRS --helm-kube-version $default_helm_kube_version --scanners vuln,misconfig . : echo fs scan success"
   stub buildkite-agent "annotate --style success \"trivy didn't find any relevant vulnerabilities in the repository<br />\" --context trivy-fs-scan : echo fs scan success" \
     "annotate --style success \"No container image was scanned due to a lack of an image reference. This is fine.<br />\" --context trivy-container-scan : echo no image scan happened" \
 
@@ -249,7 +250,7 @@ default_exit_code="--exit-code 1"
   export BUILDKITE_PLUGIN_TRIVY_IMAGE_REF="nginx:latest"
 
   stub trivy \
-    "fs $default_exit_code --scanners vuln,misconfig . : echo fs scan success" \
+    "fs $default_exit_code --helm-kube-version $default_helm_kube_version --scanners vuln,misconfig . : echo fs scan success" \
     "image $default_exit_code $BUILDKITE_PLUGIN_TRIVY_IMAGE_REF : echo container image scan success"
   stub docker \
     "images -q $BUILDKITE_PLUGIN_TRIVY_IMAGE_REF : echo ''" \
@@ -273,7 +274,7 @@ default_exit_code="--exit-code 1"
   export BUILDKITE_PLUGIN_TRIVY_IMAGE_REF="nginx:latest"
 
   stub trivy \
-    "fs $default_exit_code --scanners vuln,misconfig . : echo fs scan success" \
+    "fs $default_exit_code --helm-kube-version $default_helm_kube_version --scanners vuln,misconfig . : echo fs scan success" \
     "image $default_exit_code $BUILDKITE_PLUGIN_TRIVY_IMAGE_REF : echo container image scan success"
   stub docker \
     "images -q $BUILDKITE_PLUGIN_TRIVY_IMAGE_REF : echo 'Found image!'"
@@ -296,7 +297,7 @@ default_exit_code="--exit-code 1"
   export BUILDKITE_PLUGIN_TRIVY_IMAGE_REF="nginx:latest"
 
   stub trivy \
-    "fs $default_exit_code --scanners vuln,misconfig . : echo fs scan success" \
+    "fs $default_exit_code --helm-kube-version $default_helm_kube_version --scanners vuln,misconfig . : echo fs scan success" \
     "image $default_exit_code $BUILDKITE_PLUGIN_TRIVY_IMAGE_REF : exit 1"
   stub docker \
     "images -q $BUILDKITE_PLUGIN_TRIVY_IMAGE_REF : echo ''" \
@@ -324,7 +325,7 @@ default_exit_code="--exit-code 1"
   echo "$_TAGS_0" >> "$DOCKER_METADATA_DIR/tags"
 
   stub trivy \
-    "fs $default_exit_code --scanners vuln,misconfig . : echo fs scan success" \
+    "fs $default_exit_code --helm-kube-version $default_helm_kube_version --scanners vuln,misconfig . : echo fs scan success" \
     "image $default_exit_code $_TAGS_0 : echo container image scan success"
   stub docker \
     "images -q $_TAGS_0 : echo 'Found image!'"
@@ -350,7 +351,7 @@ default_exit_code="--exit-code 1"
   echo "$_TAGS_0" >> "$DOCKER_METADATA_DIR/tags"
 
   stub trivy \
-    "fs $default_exit_code --scanners vuln,misconfig . : echo fs scan success" \
+    "fs $default_exit_code --helm-kube-version $default_helm_kube_version --scanners vuln,misconfig . : echo fs scan success" \
     "image $default_exit_code $_TAGS_0 : echo container image scan success"
   stub docker \
     "images -q $_TAGS_0 : echo ''" \
@@ -374,6 +375,22 @@ default_exit_code="--exit-code 1"
   export BUILDKITE_PLUGIN_TRIVY_KUBE_VERSION="1.21"
 
   stub trivy "fs $default_exit_code --helm-kube-version $BUILDKITE_PLUGIN_TRIVY_KUBE_VERSION --scanners vuln,misconfig . : echo fs scan success"
+  stub buildkite-agent "annotate --style success \"trivy didn't find any relevant vulnerabilities in the repository<br />\" --context trivy-fs-scan : echo fs scan success" \
+    "annotate --style success \"No container image was scanned due to a lack of an image reference. This is fine.<br />\" --context trivy-container-scan : echo no image scan happened" \
+
+  run "$PWD/hooks/post-command"
+
+  assert_success
+  assert_output --partial "scanning filesystem"
+  assert_output --partial "fs scan success"
+  assert_output --partial "no image scan happened"
+
+  unstub trivy
+  unstub buildkite-agent
+}
+
+@test "fs scan of a test app with defaults to kube-version 1.30" {
+  stub trivy "fs $default_exit_code --helm-kube-version $default_helm_kube_version --scanners vuln,misconfig . : echo fs scan success"
   stub buildkite-agent "annotate --style success \"trivy didn't find any relevant vulnerabilities in the repository<br />\" --context trivy-fs-scan : echo fs scan success" \
     "annotate --style success \"No container image was scanned due to a lack of an image reference. This is fine.<br />\" --context trivy-container-scan : echo no image scan happened" \
 


### PR DESCRIPTION
Trivy uses helm to render helm charts for analysis. Helm client defaults to a kube version of 1.20. Trivy allows this to be overridden and the trivy-buildkite-plugin allows this argument to be specified https://github.com/equinixmetal-buildkite/trivy-buildkite-plugin/pull/118. 

This PR sets the kube version argument to a more recent version of 1.30 if it's not specified in the plugin config. This could be a more sensible default for the plugin. It prevents Trivy from failing if you don't configure the `kube-version` plugin option scan a helm chart that has a kube version of >1.20 as a requirement. 

If a different version of kube is needed, this can still be passed in as an argument as per https://github.com/equinixmetal-buildkite/trivy-buildkite-plugin/pull/118.