### PR TITLE
use ignorefile param for all trivy scans

### DIFF
--- a/hooks/post-command
+++ b/hooks/post-command
@@ -88,7 +88,7 @@ if [[ -n "${BUILDKITE_PLUGIN_TRIVY_SEVERITY:-}" ]] ; then
 fi
 
 if [[ -n "${BUILDKITE_PLUGIN_TRIVY_IGNOREFILE:-}" ]] ; then
-  fsargs+=("--ignorefile" "${BUILDKITE_PLUGIN_TRIVY_IGNOREFILE}")
+  args+=("--ignorefile" "${BUILDKITE_PLUGIN_TRIVY_IGNOREFILE}")
   echo "using ignore file '$BUILDKITE_PLUGIN_TRIVY_IGNOREFILE'"
 fi
 


### PR DESCRIPTION
in pr https://github.com/equinixmetal-buildkite/trivy-buildkite-plugin/pull/113 we added support for trivy ignorefile flag, but only for fs scans

this pr passes the flag to all trivy scans (including the image scan)